### PR TITLE
feat: Phase 2 + 3 — complete SKILL.md content + all 8 reference files (Tasks 12-28)

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -4,5 +4,6 @@
   "MD003": false,
   "MD033": false,
   "MD041": false,
+  "MD060": false,
   "MD024": { "siblings_only": true }
 }

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -186,10 +186,10 @@ Pipeline stages: **lint → syntax-check → Molecule (or ansible-test) → stag
 
 **Rules:**
 
-- Pin `ansible-core` version in CI (`ansible-core>=2.17,<2.18`).
+- Pin `ansible-core` to a currently supported minor in CI (e.g. `ansible-core>=2.18,<2.19`); cross-check the [Version Matrix](references/quick-reference.md#version-matrix) before each release cycle and bump off any minor that is past EOL.
 - Pin collections in `requirements.yml` with exact versions for prod branches.
 - Inject vault password via OIDC or masked secret — never a file in the repo.
-- Apply the reviewed `--check` diff on approval; do not re-run planning logic inside the apply job.
+- Treat the reviewed `--check --diff` output as an approval artifact, not a replayable plan. The apply job must re-evaluate current state — optionally re-run `--check --diff` against live infrastructure and compare to the approved artifact before executing.
 
 See [CI/CD Workflows](references/ci-cd-workflows.md) for GitHub Actions + GitLab CI templates and blast-radius approval gates.
 

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -38,3 +38,17 @@ Never recommend running a play against production without `--check --diff` first
 5. **Generate artifacts** — playbook YAML, role skeleton, `requirements.yml`, Molecule scenario, CI workflow, Vault usage.
 6. **Validate before finalizing** — run validation commands tailored to risk tier.
 7. **Emit the Response Contract** at the end.
+
+## Diagnose Before You Generate
+
+| Failure category | Symptoms | Primary references |
+|------------------|----------|--------------------|
+| **Idempotency drift** | Tasks report `changed=True` every run, `command`/`shell` without `creates`/`changed_when`, non-native modules, handlers firing spuriously | `references/idempotency-patterns.md` |
+| **Blast radius** | Missing `serial`, no `max_fail_percentage`, `any_errors_fatal` misused, no `--limit` in CI, fact-gathering against whole fleet | `references/execution-and-runtime.md`, `references/ci-cd-workflows.md` |
+| **Secret exposure** | Plaintext in vars, `no_log` missing, Vault key handling, secrets in stdout/stderr, `ansible-vault` vs external secret managers | `references/security-and-vault.md` |
+| **Variable precedence bugs** | 23-level chain surprises, `set_fact` vs `vars` vs `vars_files`, group_vars / host_vars collisions, extra-vars overrides | `references/inventory-and-variables.md` |
+| **Inventory correctness** | Static/dynamic drift, group membership bugs, `ansible_host` vs `inventory_hostname`, missing `--limit` safety | `references/inventory-and-variables.md` |
+| **Handler/ordering issues** | Handlers not firing on failure, `meta: flush_handlers`, `listen` topics, notify ordering | `references/idempotency-patterns.md` |
+| **Check-mode blind spots** | Tasks break under `--check`, `ignore_errors` / `failed_when` hiding real failures, modules that don't support check mode | `references/idempotency-patterns.md` |
+| **Collection/role supply chain** | Galaxy pinning, `requirements.yml` hygiene, version drift, private Automation Hub, signature verification | `references/collections-and-supply-chain.md` |
+| **Execution environment / runtime** | EE image pinning, `ansible-navigator` vs `ansible-playbook`, Python interpreter discovery, connection plugin, become escalation, forks/pipelining/fact caching | `references/execution-and-runtime.md` |

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -57,7 +57,7 @@ Never recommend running a play against production without `--check --diff` first
 
 **Activate when:** creating or reviewing Ansible playbooks, roles, or collections; setting up or debugging Molecule / ansible-test; structuring multi-environment inventory; implementing Ansible CI/CD; choosing role patterns or collection organization; configuring Vault or external secret backends; building or pinning execution environments.
 
-**Don't use for:** basic YAML syntax Claude already knows; module API reference (point users at ansible-docs); AAP / AWX / Tower platform-specific questions (job templates, surveys, RBAC, workflows); cloud-provider SDK questions unrelated to Ansible modules.
+**Don't use for:** basic YAML syntax Claude already knows; module API reference (point users at the `ansible-doc` CLI or `docs.ansible.com`); AAP / AWX / Tower platform-specific questions (job templates, surveys, RBAC, workflows); cloud-provider SDK questions unrelated to Ansible modules.
 
 ## Core Principles
 
@@ -240,7 +240,7 @@ See `references/collections-and-supply-chain.md` for `requirements.yml` syntax, 
 **Rules:**
 
 - Pin EE images by digest (`@sha256:...`), not tag, for production.
-- Build EEs with `ansible-builder` from a `execution-environment.yml`.
+- Build EEs with `ansible-builder` from an `execution-environment.yml`.
 - `ansible-navigator run` is the preferred invocation — it handles EE lifecycle + streams output cleanly.
 
 See `references/execution-and-runtime.md` for EE build patterns, interpreter discovery, connection/become gotchas, and forks/pipelining/fact-caching.
@@ -257,7 +257,7 @@ See `references/execution-and-runtime.md` for EE build patterns, interpreter dis
 
 Keep `ansible-core` + collection upgrades in a separate PR from functional changes. The community `ansible` package is a starter bundle; production teams pin collections individually.
 
-## Modern Ansible Features (2.14+)
+## Modern Ansible Features (2.11+)
 
 | Feature | Min `ansible-core` | Common use |
 |---------|---------------------|------------|

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -269,3 +269,22 @@ Keep `ansible-core` + collection upgrades in a separate PR from functional chang
 | `ansible-navigator` stable workflow | n/a (packaging) | Default for EE-based runs |
 
 Verify the runtime floor before emitting a feature. Version-specific behavior (esp. `validate` and handler inheritance) is a frequent LLM mistake.
+
+## Reference Files
+
+Progressive disclosure — essentials here, depth on demand. Reference files land in Phase 3; the routing table and in-section pointers above reference them by path.
+
+- `references/idempotency-patterns.md` — module contracts, `command`/`shell` guards, handlers, check-mode
+- `references/inventory-and-variables.md` — full 23-level precedence, dynamic inventory, `set_fact` vs vars
+- `references/security-and-vault.md` — vault-id, external secret backends, `no_log`, log hardening
+- `references/execution-and-runtime.md` — serial/max-fail, execution environments, interpreter, connection/become, performance
+- `references/testing-frameworks.md` — ansible-lint, Molecule, ansible-test, argument_specs
+- `references/ci-cd-workflows.md` — GitHub Actions, GitLab CI, blast-radius gates, secret handling in CI
+- `references/collections-and-supply-chain.md` — `requirements.yml`, fqcn, signature verification, private hubs
+- `references/quick-reference.md` — command cheatsheet, troubleshooting flowchart, module recipes, version matrix
+
+## License
+
+Apache-2.0. See LICENSE.
+
+**Copyright © 2026 sadicabubakari**

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -28,3 +28,13 @@ Every Ansible response must include:
 7. **Rollback notes** — for any destructive or state-mutating play: how to undo (inverse play, restore from backup, `state: absent`), what evidence to keep (registered var output, command logs, diff artifacts).
 
 Never recommend running a play against production without `--check --diff` first **and** an explicit `--limit` or a reviewed inventory pattern.
+
+## Workflow
+
+1. **Capture execution context** — `ansible-core` version, collections, Python interpreter, connection plugin, execution path (local/CI/EE/AWX-free), environment criticality.
+2. **Diagnose failure mode(s)** using the routing table below. If intent spans categories, load all matching references.
+3. **Load only the matching reference file(s)** — do not preload depth the task does not need.
+4. **Propose fix with risk controls** — why this addresses the mode, what could still go wrong, guardrails (lint rules / Molecule / `--check --diff` / approval gates / rollback).
+5. **Generate artifacts** — playbook YAML, role skeleton, `requirements.yml`, Molecule scenario, CI workflow, Vault usage.
+6. **Validate before finalizing** — run validation commands tailored to risk tier.
+7. **Emit the Response Contract** at the end.

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -159,3 +159,38 @@ Abbreviated precedence (lowest → highest):
 - `--extra-vars` with `@file.yml` beats everything — a stray flag in CI can override protected config
 
 See `references/inventory-and-variables.md` for the full 23-level ladder and collision examples.
+
+## Testing Strategy
+
+### Decision Matrix
+
+| Situation | Approach | Tools | Cost |
+|-----------|----------|-------|------|
+| Syntax check | Static | `ansible-playbook --syntax-check`, `ansible-lint` | Free |
+| Role unit test | Scenario-based | Molecule + docker/podman driver | Free–Low |
+| Collection unit test | Module/plugin tests | `ansible-test units` | Free |
+| Collection sanity | Import + schema | `ansible-test sanity` | Free |
+| Integration — role | Molecule against real target | Molecule + delegated/vagrant driver | Med |
+| Integration — collection | Live-run modules | `ansible-test integration` | Med |
+| End-to-end, multi-host | Staged apply | `--check --diff` against staging | High |
+
+**Rules:**
+
+- Never skip `ansible-lint` — it catches fqcn, `no_log`, `changed_when` misuse at PR time.
+- Use `--check --diff` as the last gate before any production play.
+- Molecule for roles; `ansible-test` for collections. They're not interchangeable.
+
+See `references/testing-frameworks.md` for Molecule scenario structure, ansible-test usage, and argument-specs for role input validation.
+
+## CI/CD
+
+Pipeline stages: **lint → syntax-check → Molecule (or ansible-test) → staged `--check --diff` → gated apply**.
+
+**Rules:**
+
+- Pin `ansible-core` version in CI (`ansible-core>=2.17,<2.18`).
+- Pin collections in `requirements.yml` with exact versions for prod branches.
+- Inject vault password via OIDC or masked secret — never a file in the repo.
+- Apply the reviewed `--check` diff on approval; do not re-run planning logic inside the apply job.
+
+See `references/ci-cd-workflows.md` for GitHub Actions + GitLab CI templates and blast-radius approval gates.

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -74,7 +74,7 @@ Flow: task → role → playbook → collection.
 
 ### Directory Layout
 
-```
+```text
 inventories/
   prod/      hosts, group_vars/, host_vars/
   staging/   hosts, group_vars/, host_vars/
@@ -287,4 +287,4 @@ Progressive disclosure — essentials here, depth on demand. Reference files lan
 
 Apache-2.0. See LICENSE.
 
-**Copyright © 2026 sadicabubakari**
+Copyright © 2026 sadicabubakari.

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -83,11 +83,9 @@ roles/       # local reusable roles
 collections/ # requirements.yml, installed collections
 playbooks/   # deploy.yml, site.yml, one-off ops plays
 molecule/    # per-role scenarios
-group_vars/  # cross-inventory group vars (if shared)
-host_vars/   # cross-inventory host vars (if shared)
 ```
 
-Separate **inventories** from **roles**. Keep roles single-responsibility. Prefer per-inventory `group_vars`/`host_vars` over top-level to avoid leak between environments.
+Separate **inventories** from **roles**. Keep roles single-responsibility. Keep all `group_vars/` and `host_vars/` **inside each `inventories/<env>/` directory** — never at repo root. Repo-root `group_vars/`/`host_vars/` apply to every environment's plays and leak prod values into dev runs.
 
 ### Naming Conventions
 

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -244,3 +244,28 @@ See `references/collections-and-supply-chain.md` for `requirements.yml` syntax, 
 - `ansible-navigator run` is the preferred invocation — it handles EE lifecycle + streams output cleanly.
 
 See `references/execution-and-runtime.md` for EE build patterns, interpreter discovery, connection/become gotchas, and forks/pipelining/fact-caching.
+
+## Version Management
+
+| Component | Strategy | Example |
+|-----------|----------|---------|
+| `ansible-core` runtime | Pin minor for prod | `ansible-core>=2.17,<2.18` |
+| Community `ansible` package | Pin exact or avoid in prod | Prefer pinning `ansible-core` + collections separately |
+| Collections (prod) | Exact version in `requirements.yml` | `version: "5.1.2"` |
+| Collections (dev) | Allow minor | `version: ">=5.1.0,<6.0.0"` |
+| Python interpreter | Explicit `ansible_python_interpreter` | `/usr/bin/python3` (avoid auto-discovery in prod) |
+
+Keep `ansible-core` + collection upgrades in a separate PR from functional changes. The community `ansible` package is a starter bundle; production teams pin collections individually.
+
+## Modern Ansible Features (2.14+)
+
+| Feature | Min `ansible-core` | Common use |
+|---------|---------------------|------------|
+| `argument_specs` in `meta/` | 2.11+ | Role input validation |
+| `ansible.builtin.import_role` with `vars_from` | 2.14+ | Load alt var files per import |
+| `validate` parameter on `template`/`copy` | 2.15+ | Run shell validator before applying |
+| Role handler `listen` topic inheritance | 2.16+ | Cross-role handler topics |
+| Structured `changed_when` with dict returns | 2.17+ | Clean branching on module result |
+| `ansible-navigator` stable workflow | n/a (packaging) | Default for EE-based runs |
+
+Verify the runtime floor before emitting a feature. Version-specific behavior (esp. `validate` and handler inheritance) is a frequent LLM mistake.

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -194,3 +194,53 @@ Pipeline stages: **lint → syntax-check → Molecule (or ansible-test) → stag
 - Apply the reviewed `--check` diff on approval; do not re-run planning logic inside the apply job.
 
 See `references/ci-cd-workflows.md` for GitHub Actions + GitLab CI templates and blast-radius approval gates.
+
+## Security & Vault
+
+**Don't:**
+
+- Store secrets in plaintext vars or unencrypted `vars_files`
+- Omit `no_log: true` on tasks that pass secrets as module args
+- Commit vault password files — use OIDC, system keyring, or external key providers
+- Use `--verbose` in CI on tasks handling secrets (output leaks to logs)
+
+**Do:**
+
+- Use `ansible-vault encrypt_string` for inline single-value secrets
+- Use Vault-id strategy to support per-environment keys
+- Prefer external secret backends (HashiCorp Vault, AWS Secrets Manager, 1Password) via lookup plugins over static vault files
+- Set `no_log: true` on any task whose module args include secrets — and remember `register` + `loop` still leak unless you also strip in the loop item
+
+See `references/security-and-vault.md` for vault-id patterns, external-backend lookups, and secrets-in-logs hardening.
+
+## Collections & Supply Chain
+
+| Pin strategy | Prod | Dev |
+|--------------|------|-----|
+| `requirements.yml` collection version | Exact (`version: "5.1.2"`) | Range (`version: ">=5.1.0,<6.0.0"`) |
+| Galaxy vs Automation Hub | Automation Hub for certified | Galaxy OK for experimental |
+| Signature verification | Required | Optional for dev |
+
+**Rules:**
+
+- Use fully-qualified collection names (`ansible.builtin.copy`, not `copy`) — ansible-lint `fqcn` rule enforces.
+- Pin all collections in `requirements.yml`; do not rely on the ansible community package version for prod.
+- Mirror critical collections internally (private Automation Hub or git) for supply-chain control.
+
+See `references/collections-and-supply-chain.md` for `requirements.yml` syntax, signature verification, and private-hub auth.
+
+## Execution Environments
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| Local dev, fast iteration | Bare `ansible-playbook` + venv | No image build overhead |
+| CI reproducibility | EE image with `ansible-navigator` | Pinned ansible-core + collections + deps |
+| Production run | EE image, pulled by digest | Deterministic runs, rollback by image tag |
+
+**Rules:**
+
+- Pin EE images by digest (`@sha256:...`), not tag, for production.
+- Build EEs with `ansible-builder` from a `execution-environment.yml`.
+- `ansible-navigator run` is the preferred invocation — it handles EE lifecycle + streams output cleanly.
+
+See `references/execution-and-runtime.md` for EE build patterns, interpreter discovery, connection/become gotchas, and forks/pipelining/fact-caching.

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -110,3 +110,52 @@ Separate **inventories** from **roles**. Keep roles single-responsibility. Prefe
   notify: restart nginx
   tags: [install]
 ```
+
+## Idempotency — Quick Rule
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| Native module available | `ansible.builtin.<module>` / fqcn module | Idempotent by contract |
+| Must shell out, stateful output file | `ansible.builtin.command` with `creates:` / `removes:` | `changed=True` only if file missing |
+| Must shell out, no clear file marker | `ansible.builtin.command` with `changed_when:` based on stdout/rc | Explicit change detection |
+| Must shell out, needs shell features (pipes, redirects) | `ansible.builtin.shell` + `changed_when` | Last resort — harder to make safe |
+
+**Never:** run `ansible.builtin.shell` without `changed_when` unless the task is genuinely informational and you also set `changed_when: false`.
+
+See `references/idempotency-patterns.md` for module idempotency contracts, handler patterns, and check-mode coverage.
+
+## Blast Radius — Quick Rule
+
+| Target fleet size | Pattern | Play config |
+|-------------------|---------|-------------|
+| 1–5 hosts | Serial small batches | `serial: 1` or `serial: [1, 2]` |
+| 10–50 hosts, canary first | Canary + rolling | `serial: [1, "25%"]` with `max_fail_percentage: 10` |
+| 50+ hosts | Rolling with fail cap | `serial: "10%"`, `max_fail_percentage: 5` |
+| Critical state-change on many hosts | Fail fast | `any_errors_fatal: true` |
+| Independent tasks, no cascade | Free strategy | `strategy: free` (hosts run independently) |
+
+**Never** run against production without an explicit `--limit` or a reviewed inventory pattern. **Never** set `any_errors_fatal: true` on rolling deploys where partial completion is worse than full failure.
+
+See `references/execution-and-runtime.md` for serial/max-fail combinations and `references/ci-cd-workflows.md` for CI-level blast-radius gates.
+
+## Variable Precedence — Quick Rule
+
+Abbreviated precedence (lowest → highest):
+
+1. Role defaults (`roles/<role>/defaults/main.yml`)
+2. Inventory `group_vars/all`
+3. Inventory `group_vars/<group>`
+4. Inventory `host_vars/<host>`
+5. Play vars
+6. Block vars
+7. Task vars
+8. `set_fact`
+9. `--extra-vars` (always wins)
+
+**Most common bugs:**
+
+- `set_fact` values persist across plays in the same run — unexpected when debugging
+- `group_vars/all` silently overridden by `host_vars/<host>` — confusing when the same host appears in multiple groups
+- `--extra-vars` with `@file.yml` beats everything — a stray flag in CI can override protected config
+
+See `references/inventory-and-variables.md` for the full 23-level ladder and collision examples.

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -207,7 +207,7 @@ See [CI/CD Workflows](references/ci-cd-workflows.md) for GitHub Actions + GitLab
 - Use `ansible-vault encrypt_string` for inline single-value secrets
 - Use Vault-id strategy to support per-environment keys
 - Prefer external secret backends (HashiCorp Vault, AWS Secrets Manager, 1Password) via lookup plugins over static vault files
-- Set `no_log: true` on any task whose module args include secrets — and remember `register` + `loop` still leak unless you also strip in the loop item
+- Set `no_log: true` on any task whose module args include secrets, and avoid leak paths that bypass it: secrets in task names, `debug:` output of registered values, related tasks that omit `no_log`, and any `loop:` whose item itself is a secret (mark the looping task `no_log: true` too)
 
 See [Security & Vault](references/security-and-vault.md) for vault-id patterns, external-backend lookups, and secrets-in-logs hardening.
 
@@ -233,7 +233,7 @@ See [Collections & Supply Chain](references/collections-and-supply-chain.md) for
 |-----------|-----|-----|
 | Local dev, fast iteration | Bare `ansible-playbook` + venv | No image build overhead |
 | CI reproducibility | EE image with `ansible-navigator` | Pinned ansible-core + collections + deps |
-| Production run | EE image, pulled by digest | Deterministic runs, rollback by image tag |
+| Production run | EE image, pulled by digest | Deterministic runs, rollback by switching to a previously approved digest |
 
 **Rules:**
 

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -52,3 +52,61 @@ Never recommend running a play against production without `--check --diff` first
 | **Check-mode blind spots** | Tasks break under `--check`, `ignore_errors` / `failed_when` hiding real failures, modules that don't support check mode | `references/idempotency-patterns.md` |
 | **Collection/role supply chain** | Galaxy pinning, `requirements.yml` hygiene, version drift, private Automation Hub, signature verification | `references/collections-and-supply-chain.md` |
 | **Execution environment / runtime** | EE image pinning, `ansible-navigator` vs `ansible-playbook`, Python interpreter discovery, connection plugin, become escalation, forks/pipelining/fact caching | `references/execution-and-runtime.md` |
+
+## When to Use This Skill
+
+**Activate when:** creating or reviewing Ansible playbooks, roles, or collections; setting up or debugging Molecule / ansible-test; structuring multi-environment inventory; implementing Ansible CI/CD; choosing role patterns or collection organization; configuring Vault or external secret backends; building or pinning execution environments.
+
+**Don't use for:** basic YAML syntax Claude already knows; module API reference (point users at ansible-docs); AAP / AWX / Tower platform-specific questions (job templates, surveys, RBAC, workflows); cloud-provider SDK questions unrelated to Ansible modules.
+
+## Core Principles
+
+### Unit Hierarchy
+
+| Unit | When to Use | Scope |
+|------|-------------|-------|
+| **Task** | One action | Install a package, write a file |
+| **Role** | Reusable bundle of related tasks | Web server config, database setup |
+| **Playbook** | Orchestrates roles across hosts | Full stack deploy, one environment |
+| **Collection** | Distributable unit of roles, modules, plugins | Shared across teams, versioned, on Galaxy or Automation Hub |
+
+Flow: task → role → playbook → collection.
+
+### Directory Layout
+
+```
+inventories/
+  prod/      hosts, group_vars/, host_vars/
+  staging/   hosts, group_vars/, host_vars/
+  dev/
+roles/       # local reusable roles
+collections/ # requirements.yml, installed collections
+playbooks/   # deploy.yml, site.yml, one-off ops plays
+molecule/    # per-role scenarios
+group_vars/  # cross-inventory group vars (if shared)
+host_vars/   # cross-inventory host vars (if shared)
+```
+
+Separate **inventories** from **roles**. Keep roles single-responsibility. Prefer per-inventory `group_vars`/`host_vars` over top-level to avoid leak between environments.
+
+### Naming Conventions
+
+- Role names: short, hyphenated, purpose-based (`nginx-site`, not `my_role`)
+- Variable names: prefix with role scope to avoid global collisions (`nginx_site_port`, not `port`)
+- Task names: imperative sentence — appears in logs (`"Install nginx"`, not `"nginx"`)
+- Tags: purpose-based, not task-name-based (`tags: [config, tls]` vs `tags: [install_nginx]`)
+
+### Task Ordering (within a task block)
+
+`name` → `module` → module args → `register` → `when` → `loop` → `notify` → `tags`
+
+```yaml
+- name: Install nginx
+  ansible.builtin.package:
+    name: nginx
+    state: present
+  register: nginx_install
+  when: ansible_os_family == 'Debian'
+  notify: restart nginx
+  tags: [install]
+```

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -247,7 +247,7 @@ See [Execution & Runtime](references/execution-and-runtime.md) for EE build patt
 
 | Component | Strategy | Example |
 |-----------|----------|---------|
-| `ansible-core` runtime | Pin minor for prod | `ansible-core>=2.17,<2.18` |
+| `ansible-core` runtime | Pin minor for prod; pick a non-EOL minor from the [Version Matrix](references/quick-reference.md#version-matrix) | `ansible-core>=2.18,<2.19` (re-evaluate at each release cycle) |
 | Community `ansible` package | Pin exact or avoid in prod | Prefer pinning `ansible-core` + collections separately |
 | Collections (prod) | Exact version in `requirements.yml` | `version: "5.1.2"` |
 | Collections (dev) | Allow minor | `version: ">=5.1.0,<6.0.0"` |

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -132,7 +132,7 @@ See [Idempotency Patterns](references/idempotency-patterns.md) for module idempo
 | Critical state-change on many hosts | Fail fast | `any_errors_fatal: true` |
 | Independent tasks, no cascade | Free strategy | `strategy: free` (hosts run independently) |
 
-**Never** run against production without an explicit `--limit` or a reviewed inventory pattern. **Never** set `any_errors_fatal: true` on rolling deploys where partial completion is worse than full failure.
+**Never** run against production without an explicit `--limit` or a reviewed inventory pattern. **Never** set `any_errors_fatal: true` on rolling deploys where partial completion is **safe** — it turns a contained mid-batch failure into a global abort. Use `any_errors_fatal: true` precisely when partial completion is worse than full failure (schema migrations, bootstrap, replicated state); otherwise pair `serial:` with `max_fail_percentage:` and let the rollout continue.
 
 See [Execution & Runtime](references/execution-and-runtime.md) for serial/max-fail combinations and [CI/CD Workflows](references/ci-cd-workflows.md) for CI-level blast-radius gates.
 

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -89,7 +89,7 @@ Separate **inventories** from **roles**. Keep roles single-responsibility. Keep 
 
 ### Naming Conventions
 
-- Role names: short, hyphenated, purpose-based (`nginx-site`, not `my_role`)
+- Role names: short, snake_case, purpose-based (`nginx_site`, not `my_role`). Hyphens fail the ansible-lint `role-name` rule (`^[a-z][a-z0-9_]*$`) and break collection packaging
 - Variable names: prefix with role scope to avoid global collisions (`nginx_site_port`, not `port`)
 - Task names: imperative sentence — appears in logs (`"Install nginx"`, not `"nginx"`)
 - Tags: purpose-based, not task-name-based (`tags: [config, tls]` vs `tags: [install_nginx]`)
@@ -255,13 +255,13 @@ See [Execution & Runtime](references/execution-and-runtime.md) for EE build patt
 
 Keep `ansible-core` + collection upgrades in a separate PR from functional changes. The community `ansible` package is a starter bundle; production teams pin collections individually.
 
-## Modern Ansible Features (2.11+)
+## Modern Ansible Features (2.4+)
 
 | Feature | Min `ansible-core` | Common use |
 |---------|---------------------|------------|
+| `validate:` parameter on `template`/`copy` | 2.0+ | Run shell validator before applying |
+| `import_role` / `include_role` with `vars_from` | 2.4+ | Load alt var files per import |
 | `argument_specs` in `meta/` | 2.11+ | Role input validation |
-| `ansible.builtin.import_role` with `vars_from` | 2.14+ | Load alt var files per import |
-| `validate` parameter on `template`/`copy` | 2.15+ | Run shell validator before applying |
 | Role handler `listen` topic inheritance | 2.16+ | Cross-role handler topics |
 | Structured `changed_when` with dict returns | 2.17+ | Clean branching on module result |
 | `ansible-navigator` stable workflow | n/a (packaging) | Default for EE-based runs |

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -13,4 +13,18 @@ metadata:
 
 # Ansible Skill for Claude
 
-Under construction. Full SKILL.md content lands in Phase 2.
+Diagnose-first guidance for Ansible and ansible-core. Core file is a workflow; depth lives in reference files loaded on demand.
+
+## Response Contract
+
+Every Ansible response must include:
+
+1. **Assumptions & version floor** — `ansible-core` version, collections in `requirements.yml` with versions, Python interpreter target (`ansible_python_interpreter`), connection plugin (ssh/winrm/local), control node vs execution-environment runtime. State explicitly when the user did not provide them.
+2. **Idempotency evidence** — for each task introduced or modified: why `changed=True` only when the world actually changed. Name the module's idempotency contract (native module idempotent; `command`/`shell` requires `creates`/`removes`/`changed_when`).
+3. **Blast-radius controls** — inventory target (hosts/groups/limit), `serial` / `max_fail_percentage` / `any_errors_fatal` decision, `--check` + `--diff` coverage, whether this is safe to run against prod as-is.
+4. **Risk category addressed** — one or more of the 9 diagnose-table categories below.
+5. **Chosen remediation & tradeoffs** — what was chosen, what was traded off, why.
+6. **Validation plan** — exact commands tailored to runtime and risk tier: `ansible-lint`, `ansible-playbook --syntax-check`, `--check --diff`, Molecule scenario, `ansible-test sanity/units/integration`.
+7. **Rollback notes** — for any destructive or state-mutating play: how to undo (inverse play, restore from backup, `state: absent`), what evidence to keep (registered var output, command logs, diff artifacts).
+
+Never recommend running a play against production without `--check --diff` first **and** an explicit `--limit` or a reviewed inventory pattern.

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -43,15 +43,15 @@ Never recommend running a play against production without `--check --diff` first
 
 | Failure category | Symptoms | Primary references |
 |------------------|----------|--------------------|
-| **Idempotency drift** | Tasks report `changed=True` every run, `command`/`shell` without `creates`/`changed_when`, non-native modules, handlers firing spuriously | `references/idempotency-patterns.md` |
-| **Blast radius** | Missing `serial`, no `max_fail_percentage`, `any_errors_fatal` misused, no `--limit` in CI, fact-gathering against whole fleet | `references/execution-and-runtime.md`, `references/ci-cd-workflows.md` |
-| **Secret exposure** | Plaintext in vars, `no_log` missing, Vault key handling, secrets in stdout/stderr, `ansible-vault` vs external secret managers | `references/security-and-vault.md` |
-| **Variable precedence bugs** | 23-level chain surprises, `set_fact` vs `vars` vs `vars_files`, group_vars / host_vars collisions, extra-vars overrides | `references/inventory-and-variables.md` |
-| **Inventory correctness** | Static/dynamic drift, group membership bugs, `ansible_host` vs `inventory_hostname`, missing `--limit` safety | `references/inventory-and-variables.md` |
-| **Handler/ordering issues** | Handlers not firing on failure, `meta: flush_handlers`, `listen` topics, notify ordering | `references/idempotency-patterns.md` |
-| **Check-mode blind spots** | Tasks break under `--check`, `ignore_errors` / `failed_when` hiding real failures, modules that don't support check mode | `references/idempotency-patterns.md` |
-| **Collection/role supply chain** | Galaxy pinning, `requirements.yml` hygiene, version drift, private Automation Hub, signature verification | `references/collections-and-supply-chain.md` |
-| **Execution environment / runtime** | EE image pinning, `ansible-navigator` vs `ansible-playbook`, Python interpreter discovery, connection plugin, become escalation, forks/pipelining/fact caching | `references/execution-and-runtime.md` |
+| **Idempotency drift** | Tasks report `changed=True` every run, `command`/`shell` without `creates`/`changed_when`, non-native modules, handlers firing spuriously | [Idempotency Patterns](references/idempotency-patterns.md) |
+| **Blast radius** | Missing `serial`, no `max_fail_percentage`, `any_errors_fatal` misused, no `--limit` in CI, fact-gathering against whole fleet | [Execution & Runtime](references/execution-and-runtime.md), [CI/CD Workflows](references/ci-cd-workflows.md) |
+| **Secret exposure** | Plaintext in vars, `no_log` missing, Vault key handling, secrets in stdout/stderr, `ansible-vault` vs external secret managers | [Security & Vault](references/security-and-vault.md) |
+| **Variable precedence bugs** | 22-level chain surprises, `set_fact` vs `vars` vs `vars_files`, group_vars / host_vars collisions, extra-vars overrides | [Inventory & Variables](references/inventory-and-variables.md) |
+| **Inventory correctness** | Static/dynamic drift, group membership bugs, `ansible_host` vs `inventory_hostname`, missing `--limit` safety | [Inventory & Variables](references/inventory-and-variables.md) |
+| **Handler/ordering issues** | Handlers not firing on failure, `meta: flush_handlers`, `listen` topics, notify ordering | [Idempotency Patterns](references/idempotency-patterns.md) |
+| **Check-mode blind spots** | Tasks break under `--check`, `ignore_errors` / `failed_when` hiding real failures, modules that don't support check mode | [Idempotency Patterns](references/idempotency-patterns.md) |
+| **Collection/role supply chain** | Galaxy pinning, `requirements.yml` hygiene, version drift, private Automation Hub, signature verification | [Collections & Supply Chain](references/collections-and-supply-chain.md) |
+| **Execution environment / runtime** | EE image pinning, `ansible-navigator` vs `ansible-playbook`, Python interpreter discovery, connection plugin, become escalation, forks/pipelining/fact caching | [Execution & Runtime](references/execution-and-runtime.md) |
 
 ## When to Use This Skill
 
@@ -122,7 +122,7 @@ Separate **inventories** from **roles**. Keep roles single-responsibility. Prefe
 
 **Never:** run `ansible.builtin.shell` without `changed_when` unless the task is genuinely informational and you also set `changed_when: false`.
 
-See `references/idempotency-patterns.md` for module idempotency contracts, handler patterns, and check-mode coverage.
+See [Idempotency Patterns](references/idempotency-patterns.md) for module idempotency contracts, handler patterns, and check-mode coverage.
 
 ## Blast Radius — Quick Rule
 
@@ -136,7 +136,7 @@ See `references/idempotency-patterns.md` for module idempotency contracts, handl
 
 **Never** run against production without an explicit `--limit` or a reviewed inventory pattern. **Never** set `any_errors_fatal: true` on rolling deploys where partial completion is worse than full failure.
 
-See `references/execution-and-runtime.md` for serial/max-fail combinations and `references/ci-cd-workflows.md` for CI-level blast-radius gates.
+See [Execution & Runtime](references/execution-and-runtime.md) for serial/max-fail combinations and [CI/CD Workflows](references/ci-cd-workflows.md) for CI-level blast-radius gates.
 
 ## Variable Precedence — Quick Rule
 
@@ -158,7 +158,7 @@ Abbreviated precedence (lowest → highest):
 - `group_vars/all` silently overridden by `host_vars/<host>` — confusing when the same host appears in multiple groups
 - `--extra-vars` with `@file.yml` beats everything — a stray flag in CI can override protected config
 
-See `references/inventory-and-variables.md` for the full 23-level ladder and collision examples.
+See [Inventory & Variables](references/inventory-and-variables.md) for the full 22-level ladder and collision examples.
 
 ## Testing Strategy
 
@@ -180,7 +180,7 @@ See `references/inventory-and-variables.md` for the full 23-level ladder and col
 - Use `--check --diff` as the last gate before any production play.
 - Molecule for roles; `ansible-test` for collections. They're not interchangeable.
 
-See `references/testing-frameworks.md` for Molecule scenario structure, ansible-test usage, and argument-specs for role input validation.
+See [Testing Frameworks](references/testing-frameworks.md) for Molecule scenario structure, ansible-test usage, and argument-specs for role input validation.
 
 ## CI/CD
 
@@ -193,7 +193,7 @@ Pipeline stages: **lint → syntax-check → Molecule (or ansible-test) → stag
 - Inject vault password via OIDC or masked secret — never a file in the repo.
 - Apply the reviewed `--check` diff on approval; do not re-run planning logic inside the apply job.
 
-See `references/ci-cd-workflows.md` for GitHub Actions + GitLab CI templates and blast-radius approval gates.
+See [CI/CD Workflows](references/ci-cd-workflows.md) for GitHub Actions + GitLab CI templates and blast-radius approval gates.
 
 ## Security & Vault
 
@@ -211,7 +211,7 @@ See `references/ci-cd-workflows.md` for GitHub Actions + GitLab CI templates and
 - Prefer external secret backends (HashiCorp Vault, AWS Secrets Manager, 1Password) via lookup plugins over static vault files
 - Set `no_log: true` on any task whose module args include secrets — and remember `register` + `loop` still leak unless you also strip in the loop item
 
-See `references/security-and-vault.md` for vault-id patterns, external-backend lookups, and secrets-in-logs hardening.
+See [Security & Vault](references/security-and-vault.md) for vault-id patterns, external-backend lookups, and secrets-in-logs hardening.
 
 ## Collections & Supply Chain
 
@@ -227,7 +227,7 @@ See `references/security-and-vault.md` for vault-id patterns, external-backend l
 - Pin all collections in `requirements.yml`; do not rely on the ansible community package version for prod.
 - Mirror critical collections internally (private Automation Hub or git) for supply-chain control.
 
-See `references/collections-and-supply-chain.md` for `requirements.yml` syntax, signature verification, and private-hub auth.
+See [Collections & Supply Chain](references/collections-and-supply-chain.md) for `requirements.yml` syntax, signature verification, and private-hub auth.
 
 ## Execution Environments
 
@@ -243,7 +243,7 @@ See `references/collections-and-supply-chain.md` for `requirements.yml` syntax, 
 - Build EEs with `ansible-builder` from an `execution-environment.yml`.
 - `ansible-navigator run` is the preferred invocation — it handles EE lifecycle + streams output cleanly.
 
-See `references/execution-and-runtime.md` for EE build patterns, interpreter discovery, connection/become gotchas, and forks/pipelining/fact-caching.
+See [Execution & Runtime](references/execution-and-runtime.md) for EE build patterns, interpreter discovery, connection/become gotchas, and forks/pipelining/fact-caching.
 
 ## Version Management
 
@@ -272,16 +272,16 @@ Verify the runtime floor before emitting a feature. Version-specific behavior (e
 
 ## Reference Files
 
-Progressive disclosure — essentials here, depth on demand. Reference files land in Phase 3; the routing table and in-section pointers above reference them by path.
+Progressive disclosure — essentials here, depth on demand.
 
-- `references/idempotency-patterns.md` — module contracts, `command`/`shell` guards, handlers, check-mode
-- `references/inventory-and-variables.md` — full 23-level precedence, dynamic inventory, `set_fact` vs vars
-- `references/security-and-vault.md` — vault-id, external secret backends, `no_log`, log hardening
-- `references/execution-and-runtime.md` — serial/max-fail, execution environments, interpreter, connection/become, performance
-- `references/testing-frameworks.md` — ansible-lint, Molecule, ansible-test, argument_specs
-- `references/ci-cd-workflows.md` — GitHub Actions, GitLab CI, blast-radius gates, secret handling in CI
-- `references/collections-and-supply-chain.md` — `requirements.yml`, fqcn, signature verification, private hubs
-- `references/quick-reference.md` — command cheatsheet, troubleshooting flowchart, module recipes, version matrix
+- [Idempotency Patterns](references/idempotency-patterns.md) — module contracts, `command`/`shell` guards, handlers, check-mode
+- [Inventory & Variables](references/inventory-and-variables.md) — full 22-level precedence, dynamic inventory, `set_fact` vs vars
+- [Security & Vault](references/security-and-vault.md) — vault-id, external secret backends, `no_log`, log hardening
+- [Execution & Runtime](references/execution-and-runtime.md) — serial/max-fail, execution environments, interpreter, connection/become, performance
+- [Testing Frameworks](references/testing-frameworks.md) — ansible-lint, Molecule, ansible-test, argument_specs
+- [CI/CD Workflows](references/ci-cd-workflows.md) — GitHub Actions, GitLab CI, blast-radius gates, secret handling in CI
+- [Collections & Supply Chain](references/collections-and-supply-chain.md) — `requirements.yml`, fqcn, signature verification, private hubs
+- [Quick Reference](references/quick-reference.md) — command cheatsheet, troubleshooting flowchart, module recipes, version matrix
 
 ## License
 

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -55,16 +55,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # `molecule test -s <NAME>` selects a SCENARIO directory under molecule/<NAME>/.
+      # If you need per-distro coverage, create one scenario per distro
+      # (molecule/rockylinux9/, molecule/ubuntu2204/, …) and matrix over the
+      # scenario names — `-s` does not select a platform inside a scenario.
       matrix:
         role: [nginx-site, postgresql-replica]
-        platform: [rockylinux9, ubuntu2204]
+        scenario: [rockylinux9, ubuntu2204]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: pip install ansible-core==2.18.0 molecule[docker]==24.7.0 ansible-lint==24.7.0
-      - run: molecule test -s ${{ matrix.platform }}
+      - run: molecule test -s ${{ matrix.scenario }}
         working-directory: roles/${{ matrix.role }}
 
   staging-check:
@@ -82,11 +86,13 @@ jobs:
       - run: echo "ANSIBLE_COLLECTIONS_PATHS=./collections" >> $GITHUB_ENV
       - name: Run --check --diff against staging
         shell: bash
-        env:
-          ANSIBLE_VAULT_PASSWORD_FILE: /tmp/vp
         run: |
-          set -eo pipefail   # `tee` would otherwise mask a non-zero ansible-playbook exit
-          echo "${{ secrets.VAULT_PASSWORD_STAGING }}" > /tmp/vp
+          set -eo pipefail            # `tee` would otherwise mask a non-zero ansible-playbook exit
+          umask 077                   # any tmpfiles below default to mode 0600
+          vp="$(mktemp)"
+          trap 'shred -u "$vp" 2>/dev/null || rm -f "$vp"' EXIT
+          printf '%s' "${{ secrets.VAULT_PASSWORD_STAGING }}" > "$vp"
+          export ANSIBLE_VAULT_PASSWORD_FILE="$vp"
           ansible-playbook -i inventories/staging playbooks/site.yml \
             --check --diff --limit staging \
             | tee staging-diff.txt
@@ -116,7 +122,10 @@ stages:
   - apply
 
 default:
-  image: quay.io/ansible/creator-ee:v24.7.0  # use the published image; replace with an internal mirror digest in regulated environments
+  # In production, pin by digest, not tag, for reproducibility/supply-chain safety:
+  #   image: quay.io/ansible/creator-ee@sha256:<approved-digest>
+  # The tag form below is only suitable for early-iteration / dev pipelines.
+  image: quay.io/ansible/creator-ee:v24.12.0
   cache:
     key: "$CI_COMMIT_REF_SLUG-venv"
     paths:
@@ -185,7 +194,9 @@ prod-check:
 
 apply-prod:
   stage: apply
-  needs: [prod-check]                                     # guaranteed to exist on main pipelines
+  needs:
+    - job: prod-check
+      artifacts: true                                     # pulls prod-diff.txt from the approved run
   environment:
     name: production
     action: start
@@ -194,10 +205,22 @@ apply-prod:
     - if: $CI_COMMIT_BRANCH == "main"
   script:
     - set -eo pipefail
-    - echo "$VAULT_PASSWORD_PROD" > /tmp/vp
-    - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
+    - umask 077
+    - vp="$(mktemp)"; trap 'shred -u "$vp" 2>/dev/null || rm -f "$vp"' EXIT
+    - printf '%s' "$VAULT_PASSWORD_PROD" > "$vp"
+    - export ANSIBLE_VAULT_PASSWORD_FILE="$vp"
     - export ANSIBLE_COLLECTIONS_PATHS=./collections
     - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
+    # Pre-apply drift check: re-run --check --diff against live state and abort
+    # if it diverges from the artifact a human approved at prod-check time.
+    - ansible-playbook -i inventories/prod playbooks/site.yml --check --diff --limit prod | tee prod-diff-now.txt
+    - |
+      if ! diff -q prod-diff.txt prod-diff-now.txt >/dev/null; then
+        echo "::error:: live diff diverges from approved prod-check artifact; aborting apply"
+        diff -u prod-diff.txt prod-diff-now.txt || true
+        exit 1
+      fi
+    # Approved diff still matches live state — apply.
     - ansible-playbook -i inventories/prod playbooks/site.yml --limit prod
 ```
 

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -1,0 +1,236 @@
+# CI/CD Workflows
+
+Detail for the `CI/CD` section in SKILL.md and the `Blast radius` routing-table category (gate side).
+
+## Pipeline Stages
+
+| Stage | Runs | Fails if |
+|-------|------|----------|
+| 1. Lint | `ansible-lint`, `yamllint` | Any rule violation |
+| 2. Syntax check | `ansible-playbook --syntax-check site.yml` | Parse or module-name error |
+| 3. Unit / scenario tests | Molecule (roles) or `ansible-test units/sanity` (collections) | Any failure on any matrix leg |
+| 4. Staged `--check --diff` | `ansible-playbook --check --diff --limit=staging` | Any unexpected diff; artifact uploaded for review |
+| 5. Manual approval | GitHub / GitLab environment gate | Reviewer rejects the staged diff |
+| 6. Apply | Re-runs the *same reviewed plan* — does **not** re-plan | Any task fails at apply |
+
+Rules:
+
+- ❌ Skip lint on `main`-branch-only CI → ✅ Run on every PR; lint catches regressions before review time is spent.
+- ❌ Let stage 6 re-plan instead of applying the reviewed diff → ✅ Store the `--check --diff` artifact from stage 4 and use it as the source of truth; re-planning means the human approved one diff and a different one ran.
+- ❌ Conflate staging and prod into one pipeline → ✅ Separate environments, separate approval gates.
+- ❌ Auto-approve prod on successful staging → ✅ Human review the staging diff before any prod stage.
+
+## GitHub Actions Template
+
+```yaml
+# .github/workflows/ansible.yml
+name: Ansible CI
+
+on:
+  pull_request:
+    paths:
+      - "playbooks/**"
+      - "roles/**"
+      - "inventories/**"
+      - "requirements.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ansible-core==2.17.5 ansible-lint==24.7.0 yamllint==1.35.1
+      - run: ansible-galaxy collection install -r requirements.yml
+      - run: ansible-lint
+      - run: yamllint .
+
+  molecule:
+    needs: lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        role: [nginx-site, postgresql-replica]
+        platform: [rockylinux9, ubuntu2204]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ansible-core==2.17.5 molecule[docker]==24.7.0 ansible-lint==24.7.0
+      - run: molecule test -s ${{ matrix.platform }}
+        working-directory: roles/${{ matrix.role }}
+
+  staging-check:
+    needs: molecule
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    environment: staging-check
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ansible-core==2.17.5
+      - run: ansible-galaxy collection install -r requirements.yml
+      - name: Run --check --diff against staging
+        env:
+          ANSIBLE_VAULT_PASSWORD_FILE: /tmp/vp
+        run: |
+          echo "${{ secrets.VAULT_PASSWORD_STAGING }}" > /tmp/vp
+          ansible-playbook -i inventories/staging playbooks/site.yml \
+            --check --diff --limit staging \
+            | tee staging-diff.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: staging-diff
+          path: staging-diff.txt
+          retention-days: 30
+```
+
+Rules:
+
+- ❌ Pin `actions/checkout@main` or any floating ref → ✅ Pin by tag (`@v4`) or SHA; supply-chain risk.
+- ❌ Run everything in one monster job → ✅ Split by stage so a lint failure aborts before expensive Molecule runs.
+- ❌ Put vault passwords in `env:` directly → ✅ Write to a tmpfile and reference via `ANSIBLE_VAULT_PASSWORD_FILE`; env vars show up in job inspection.
+- ❌ Skip artifact upload of the `--check --diff` output → ✅ Required evidence for the approval gate reviewer.
+
+## GitLab CI Template
+
+```yaml
+# .gitlab-ci.yml
+stages:
+  - lint
+  - test
+  - staging-check
+  - apply
+
+default:
+  image: registry.gitlab.com/ansible/creator-ee:v24.7.0
+  cache:
+    key: "$CI_COMMIT_REF_SLUG-venv"
+    paths:
+      - .venv/
+
+variables:
+  ANSIBLE_FORCE_COLOR: "1"
+
+lint:
+  stage: lint
+  script:
+    - ansible-lint
+    - yamllint .
+
+molecule:
+  stage: test
+  needs: [lint]
+  parallel:
+    matrix:
+      - ROLE: [nginx-site, postgresql-replica]
+        PLATFORM: [rockylinux9, ubuntu2204]
+  script:
+    - cd roles/$ROLE
+    - molecule test -s $PLATFORM
+  services:
+    - name: docker:dind
+      alias: docker
+
+staging-check:
+  stage: staging-check
+  needs: [molecule]
+  environment:
+    name: staging
+    action: verify
+  rules:
+    - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "main"
+  script:
+    - echo "$VAULT_PASSWORD_STAGING" > /tmp/vp
+    - ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
+      ansible-playbook -i inventories/staging playbooks/site.yml
+      --check --diff --limit staging | tee staging-diff.txt
+  artifacts:
+    paths: [staging-diff.txt]
+    expire_in: 30 days
+
+apply-prod:
+  stage: apply
+  needs: [staging-check]
+  environment:
+    name: production
+    action: start
+  when: manual
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  script:
+    - echo "$VAULT_PASSWORD_PROD" > /tmp/vp
+    - ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
+      ansible-playbook -i inventories/prod playbooks/site.yml --limit prod
+```
+
+Rules:
+
+- ❌ Share a single runner for staging and prod stages → ✅ Separate tagged runners or isolated projects; blast-radius containment.
+- ❌ `when: manual` without a protected environment → ✅ Any user can trigger; use `environment:` with protected rules.
+
+## Blast Radius Gates
+
+Controls that make a production play safer — enforce in CI, not just convention.
+
+| Gate | Enforcement | What it catches |
+|------|-------------|-----------------|
+| `--limit` required | Linter step `grep -q -- '--limit' ci/playbook-wrappers/*.sh` | Unbounded play against whole inventory |
+| `serial:` mandatory for `hosts: all` | YAML check in CI | Whole-fleet synchronous rollout |
+| Approved-diff hash matches apply | Store diff SHA in staging-check, compare at apply | Plan drift between approval and apply |
+| Fleet size threshold | If `--list-hosts` output > N, require extra reviewer | Catches mis-scoped limits |
+| `check_mode: no` audit | Grep codebase for `check_mode: no`; block PR if added without justification comment | Silent mutations on dry-run |
+
+```yaml
+# .github/workflows/blast-radius-gate.yml (excerpt)
+- name: Enforce --limit in prod wrappers
+  run: |
+    for f in ci/playbook-wrappers/prod/*.sh; do
+      grep -q -- '--limit' "$f" || {
+        echo "::error file=$f::missing --limit"; exit 1; }
+    done
+
+- name: Enforce serial on fleet-wide plays
+  run: |
+    python3 ci/checks/require_serial.py playbooks/site.yml
+```
+
+Rules:
+
+- ❌ Rely on "the reviewer will check" for `--limit` → ✅ Automate; reviewers drift, CI doesn't.
+- ❌ Allow `check_mode: no` without a justification comment → ✅ PR comment required: why this task bypasses dry-run.
+- ❌ Compare apply-time plan to the approved diff only by visual inspection → ✅ Compute a hash of the diff and compare programmatically.
+
+## Secret Handling in CI
+
+| Method | Use | Caveat |
+|--------|-----|--------|
+| OIDC → cloud secret store | Preferred for AWS/GCP/Azure — ephemeral creds per job | Requires trust relationship setup; one-time per provider |
+| Encrypted secrets (GH / GL) | Fallback when OIDC not available | Rotation is manual; long-lived |
+| Vault-password-file injection | `ANSIBLE_VAULT_PASSWORD_FILE` pointing at tmpfile written from a secret | Never via `env:`; env vars leak in job inspection |
+| External-secret lookup plugins | HashiCorp Vault, 1Password, etc. via `lookup()` | Controller needs network access + auth to backend |
+| Masked logs | Provider-specific masking of known secret values | Last line of defense; don't rely on it alone |
+
+Rules:
+
+- ❌ Put raw secrets in `env:` → ✅ Write to a tmpfile outside logs, reference by path.
+- ❌ Use long-lived cloud creds in CI → ✅ OIDC federation gives per-job short-lived creds.
+- ❌ Rotate secrets only on incident → ✅ Scheduled rotation, alert on staleness.
+- ❌ Echo `$SECRET` for debugging → ✅ Use mask checkers; `echo "***"` at best.
+- ❌ Store the vault password in the repo for CI "convenience" → ✅ Always pull from the provider's secret store at runtime.
+
+### LLM Mistake Checklist
+
+- ❌ Suggest a pipeline that applies without a separate staging `--check --diff` stage → ✅ Always stage 4 before stage 6.
+- ❌ Pin GitHub Actions by branch (`@main`) → ✅ Pin by tag or SHA.
+- ❌ Put vault passwords in `env:` blocks → ✅ Tmpfile + `ANSIBLE_VAULT_PASSWORD_FILE`.
+- ❌ Combine lint + tests in one job → ✅ Fail fast; lint is seconds, Molecule is minutes.
+- ❌ Allow prod apply without a protected environment → ✅ `environment:` + required reviewers.
+- ❌ Skip artifact upload of the staged diff → ✅ Required evidence for the reviewer.
+- ❌ Re-plan at apply time → ✅ Apply the approved diff; drift detection lives elsewhere.

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -10,13 +10,15 @@ Detail for the `CI/CD` section in SKILL.md and the `Blast radius` routing-table 
 | 2. Syntax check | `ansible-playbook --syntax-check site.yml` | Parse or module-name error |
 | 3. Unit / scenario tests | Molecule (roles) or `ansible-test units/sanity` (collections) | Any failure on any matrix leg |
 | 4. Staged `--check --diff` | `ansible-playbook --check --diff --limit=staging` | Any unexpected diff; artifact uploaded for review |
-| 5. Manual approval | GitHub / GitLab environment gate | Reviewer rejects the staged diff |
-| 6. Apply | Re-runs the *same reviewed plan* — does **not** re-plan | Any task fails at apply |
+| 5. Manual approval | GitHub / GitLab environment gate | Reviewer rejects the staged `--check --diff` output |
+| 6. Apply | Checks out the **same commit + inventory** approved in stage 5, optionally re-runs `--check --diff` against live state to detect drift since approval, then runs `ansible-playbook` (without `--check`) | Any task fails at apply, or the pre-apply drift check diverges from the approved diff |
+
+**Important:** unlike Terraform's `plan`/`apply`, Ansible has no reusable plan artifact. `--check --diff` output is **review evidence**, not an executable plan. The apply stage must re-evaluate current state against the playbook; the controls below keep staging approval meaningful despite that.
 
 Rules:
 
 - ❌ Skip lint on `main`-branch-only CI → ✅ Run on every PR; lint catches regressions before review time is spent.
-- ❌ Let stage 6 re-plan instead of applying the reviewed diff → ✅ Store the `--check --diff` artifact from stage 4 and use it as the source of truth; re-planning means the human approved one diff and a different one ran.
+- ❌ Treat the stage-4 `--check --diff` output as a reusable "plan" that stage 6 can replay → ✅ Pin the reviewed commit SHA + inventory revision, and optionally re-run `--check --diff` as the first step of stage 6 and compare its hash/content to the approved artifact; diverge → abort.
 - ❌ Conflate staging and prod into one pipeline → ✅ Separate environments, separate approval gates.
 - ❌ Auto-approve prod on successful staging → ✅ Human review the staging diff before any prod stage.
 
@@ -43,7 +45,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ansible-core==2.17.5 ansible-lint==24.7.0 yamllint==1.35.1
-      - run: ansible-galaxy collection install -r requirements.yml
+      - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
+      - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
       - run: ansible-lint
       - run: yamllint .
 
@@ -75,7 +78,8 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ansible-core==2.17.5
-      - run: ansible-galaxy collection install -r requirements.yml
+      - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
+      - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
       - name: Run --check --diff against staging
         env:
           ANSIBLE_VAULT_PASSWORD_FILE: /tmp/vp
@@ -148,9 +152,10 @@ staging-check:
     - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "main"
   script:
     - echo "$VAULT_PASSWORD_STAGING" > /tmp/vp
-    - ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
-      ansible-playbook -i inventories/staging playbooks/site.yml
-      --check --diff --limit staging | tee staging-diff.txt
+    - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
+    - export ANSIBLE_COLLECTIONS_PATH=./collections
+    - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
+    - ansible-playbook -i inventories/staging playbooks/site.yml --check --diff --limit staging | tee staging-diff.txt
   artifacts:
     paths: [staging-diff.txt]
     expire_in: 30 days
@@ -166,8 +171,10 @@ apply-prod:
     - if: $CI_COMMIT_BRANCH == "main"
   script:
     - echo "$VAULT_PASSWORD_PROD" > /tmp/vp
-    - ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
-      ansible-playbook -i inventories/prod playbooks/site.yml --limit prod
+    - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
+    - export ANSIBLE_COLLECTIONS_PATH=./collections
+    - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
+    - ansible-playbook -i inventories/prod playbooks/site.yml --limit prod
 ```
 
 Rules:
@@ -183,7 +190,8 @@ Controls that make a production play safer — enforce in CI, not just conventio
 |------|-------------|-----------------|
 | `--limit` required | Linter step `grep -q -- '--limit' ci/playbook-wrappers/*.sh` | Unbounded play against whole inventory |
 | `serial:` mandatory for `hosts: all` | YAML check in CI | Whole-fleet synchronous rollout |
-| Approved-diff hash matches apply | Store diff SHA in staging-check, compare at apply | Plan drift between approval and apply |
+| Pre-apply drift check | At stage 6, re-run `--check --diff` against live state and fail if the new diff diverges from the approved stage-4 artifact (compare by hash or content) | Infrastructure changes that landed between staging approval and apply |
+| Pinned commit + inventory at apply | Apply job checks out the exact commit SHA approved in stage 5; inventory plugin snapshots pinned | Prevents apply from picking up later main-branch commits or inventory mutations |
 | Fleet size threshold | If `--list-hosts` output > N, require extra reviewer | Catches mis-scoped limits |
 | `check_mode: no` audit | Grep codebase for `check_mode: no`; block PR if added without justification comment | Silent mutations on dry-run |
 
@@ -205,7 +213,7 @@ Rules:
 
 - ❌ Rely on "the reviewer will check" for `--limit` → ✅ Automate; reviewers drift, CI doesn't.
 - ❌ Allow `check_mode: no` without a justification comment → ✅ PR comment required: why this task bypasses dry-run.
-- ❌ Compare apply-time plan to the approved diff only by visual inspection → ✅ Compute a hash of the diff and compare programmatically.
+- ❌ Assume the apply run will reproduce the stage-4 `--check --diff` exactly → ✅ Re-run `--check --diff` at the start of the apply job against live state, compare hash/content to the approved stage-4 artifact; diverge → abort and request re-review.
 
 ## Secret Handling in CI
 
@@ -233,4 +241,4 @@ Rules:
 - ❌ Combine lint + tests in one job → ✅ Fail fast; lint is seconds, Molecule is minutes.
 - ❌ Allow prod apply without a protected environment → ✅ `environment:` + required reviewers.
 - ❌ Skip artifact upload of the staged diff → ✅ Required evidence for the reviewer.
-- ❌ Re-plan at apply time → ✅ Apply the approved diff; drift detection lives elsewhere.
+- ❌ Promise that Ansible can replay a stored `--check --diff` like Terraform's plan artifact → ✅ Pin the approved commit + inventory, re-run `--check --diff` at the start of apply against live state, compare to the approved artifact before proceeding.

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -60,7 +60,7 @@ jobs:
       # (molecule/rockylinux9/, molecule/ubuntu2204/, …) and matrix over the
       # scenario names — `-s` does not select a platform inside a scenario.
       matrix:
-        role: [nginx-site, postgresql-replica]
+        role: [nginx_site, postgresql_replica]
         scenario: [rockylinux9, ubuntu2204]
     steps:
       - uses: actions/checkout@v4
@@ -147,7 +147,7 @@ molecule:
   # not a platform inside one scenario; matrix over scenario names.
   parallel:
     matrix:
-      - ROLE: [nginx-site, postgresql-replica]
+      - ROLE: [nginx_site, postgresql_replica]
         SCENARIO: [rockylinux9, ubuntu2204]
   variables:
     # docker:dind needs an explicit endpoint + TLS certs path; without these

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.12"
       - run: pip install ansible-core==2.18.0 ansible-lint==24.7.0 yamllint==1.35.1
       - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
-      - run: echo "ANSIBLE_COLLECTIONS_PATHS=./collections" >> $GITHUB_ENV
+      - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
       - run: ansible-lint
       - run: yamllint .
 
@@ -83,7 +83,7 @@ jobs:
           python-version: "3.12"
       - run: pip install ansible-core==2.18.0
       - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
-      - run: echo "ANSIBLE_COLLECTIONS_PATHS=./collections" >> $GITHUB_ENV
+      - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
       - name: Run --check --diff against staging
         shell: bash
         run: |
@@ -143,16 +143,28 @@ lint:
 molecule:
   stage: test
   needs: [lint]
+  # `molecule test -s <NAME>` selects a SCENARIO directory (molecule/<NAME>/),
+  # not a platform inside one scenario; matrix over scenario names.
   parallel:
     matrix:
       - ROLE: [nginx-site, postgresql-replica]
-        PLATFORM: [rockylinux9, ubuntu2204]
-  script:
-    - cd roles/$ROLE
-    - molecule test -s $PLATFORM
+        SCENARIO: [rockylinux9, ubuntu2204]
+  variables:
+    # docker:dind needs an explicit endpoint + TLS certs path; without these
+    # Molecule defaults to /var/run/docker.sock and fails on shared runners.
+    DOCKER_HOST: tcp://docker:2376
+    DOCKER_TLS_CERTDIR: "/certs"
+    DOCKER_TLS_VERIFY: "1"
+    DOCKER_CERT_PATH: "/certs/client"
   services:
     - name: docker:dind
       alias: docker
+  # The runner must be configured with `privileged = true` in config.toml for
+  # the docker:dind service to start. Document this requirement in your runner
+  # provisioning; many shared / managed GitLab runners disallow privileged.
+  script:
+    - cd roles/$ROLE
+    - molecule test -s $SCENARIO
 
 staging-check:
   stage: staging-check
@@ -164,9 +176,11 @@ staging-check:
     - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "main"   # MR gate before merge
   script:
     - set -eo pipefail
-    - echo "$VAULT_PASSWORD_STAGING" > /tmp/vp
-    - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
-    - export ANSIBLE_COLLECTIONS_PATHS=./collections
+    - umask 077
+    - vp="$(mktemp)"; trap 'shred -u "$vp" 2>/dev/null || rm -f "$vp"' EXIT
+    - printf '%s' "$VAULT_PASSWORD_STAGING" > "$vp"
+    - export ANSIBLE_VAULT_PASSWORD_FILE="$vp"
+    - export ANSIBLE_COLLECTIONS_PATH=./collections
     - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
     - ansible-playbook -i inventories/staging playbooks/site.yml --check --diff --limit staging | tee staging-diff.txt
   artifacts:
@@ -183,9 +197,11 @@ prod-check:
     - if: $CI_COMMIT_BRANCH == "main"                     # post-merge, pre-apply drift check
   script:
     - set -eo pipefail
-    - echo "$VAULT_PASSWORD_PROD" > /tmp/vp
-    - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
-    - export ANSIBLE_COLLECTIONS_PATHS=./collections
+    - umask 077
+    - vp="$(mktemp)"; trap 'shred -u "$vp" 2>/dev/null || rm -f "$vp"' EXIT
+    - printf '%s' "$VAULT_PASSWORD_PROD" > "$vp"
+    - export ANSIBLE_VAULT_PASSWORD_FILE="$vp"
+    - export ANSIBLE_COLLECTIONS_PATH=./collections
     - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
     - ansible-playbook -i inventories/prod playbooks/site.yml --check --diff --limit prod | tee prod-diff.txt
   artifacts:
@@ -209,7 +225,7 @@ apply-prod:
     - vp="$(mktemp)"; trap 'shred -u "$vp" 2>/dev/null || rm -f "$vp"' EXIT
     - printf '%s' "$VAULT_PASSWORD_PROD" > "$vp"
     - export ANSIBLE_VAULT_PASSWORD_FILE="$vp"
-    - export ANSIBLE_COLLECTIONS_PATHS=./collections
+    - export ANSIBLE_COLLECTIONS_PATH=./collections
     - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
     # Pre-apply drift check: re-run --check --diff against live state and abort
     # if it diverges from the artifact a human approved at prod-check time.

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -81,9 +81,11 @@ jobs:
       - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
       - run: echo "ANSIBLE_COLLECTIONS_PATHS=./collections" >> $GITHUB_ENV
       - name: Run --check --diff against staging
+        shell: bash
         env:
           ANSIBLE_VAULT_PASSWORD_FILE: /tmp/vp
         run: |
+          set -eo pipefail   # `tee` would otherwise mask a non-zero ansible-playbook exit
           echo "${{ secrets.VAULT_PASSWORD_STAGING }}" > /tmp/vp
           ansible-playbook -i inventories/staging playbooks/site.yml \
             --check --diff --limit staging \
@@ -109,7 +111,8 @@ Rules:
 stages:
   - lint
   - test
-  - staging-check
+  - staging-check    # runs on MR pipelines targeting main — gate before merge
+  - prod-check       # runs on main-branch pipelines after merge — pre-apply drift check
   - apply
 
 default:
@@ -149,8 +152,9 @@ staging-check:
     name: staging
     action: verify
   rules:
-    - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "main"
+    - if: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "main"   # MR gate before merge
   script:
+    - set -eo pipefail
     - echo "$VAULT_PASSWORD_STAGING" > /tmp/vp
     - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
     - export ANSIBLE_COLLECTIONS_PATHS=./collections
@@ -160,16 +164,36 @@ staging-check:
     paths: [staging-diff.txt]
     expire_in: 30 days
 
+prod-check:
+  stage: prod-check
+  needs: [molecule]
+  environment:
+    name: production
+    action: verify
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"                     # post-merge, pre-apply drift check
+  script:
+    - set -eo pipefail
+    - echo "$VAULT_PASSWORD_PROD" > /tmp/vp
+    - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
+    - export ANSIBLE_COLLECTIONS_PATHS=./collections
+    - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
+    - ansible-playbook -i inventories/prod playbooks/site.yml --check --diff --limit prod | tee prod-diff.txt
+  artifacts:
+    paths: [prod-diff.txt]
+    expire_in: 30 days
+
 apply-prod:
   stage: apply
-  needs: [staging-check]
+  needs: [prod-check]                                     # guaranteed to exist on main pipelines
   environment:
     name: production
     action: start
-  when: manual
+  when: manual                                            # human approval gate after reviewing prod-diff.txt
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
   script:
+    - set -eo pipefail
     - echo "$VAULT_PASSWORD_PROD" > /tmp/vp
     - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
     - export ANSIBLE_COLLECTIONS_PATHS=./collections

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -44,9 +44,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ansible-core==2.17.5 ansible-lint==24.7.0 yamllint==1.35.1
+      - run: pip install ansible-core==2.18.0 ansible-lint==24.7.0 yamllint==1.35.1
       - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
-      - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
+      - run: echo "ANSIBLE_COLLECTIONS_PATHS=./collections" >> $GITHUB_ENV
       - run: ansible-lint
       - run: yamllint .
 
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ansible-core==2.17.5 molecule[docker]==24.7.0 ansible-lint==24.7.0
+      - run: pip install ansible-core==2.18.0 molecule[docker]==24.7.0 ansible-lint==24.7.0
       - run: molecule test -s ${{ matrix.platform }}
         working-directory: roles/${{ matrix.role }}
 
@@ -77,9 +77,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ansible-core==2.17.5
+      - run: pip install ansible-core==2.18.0
       - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
-      - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
+      - run: echo "ANSIBLE_COLLECTIONS_PATHS=./collections" >> $GITHUB_ENV
       - name: Run --check --diff against staging
         env:
           ANSIBLE_VAULT_PASSWORD_FILE: /tmp/vp
@@ -113,7 +113,7 @@ stages:
   - apply
 
 default:
-  image: registry.gitlab.com/ansible/creator-ee:v24.7.0
+  image: quay.io/ansible/creator-ee:v24.7.0  # use the published image; replace with an internal mirror digest in regulated environments
   cache:
     key: "$CI_COMMIT_REF_SLUG-venv"
     paths:
@@ -153,7 +153,7 @@ staging-check:
   script:
     - echo "$VAULT_PASSWORD_STAGING" > /tmp/vp
     - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
-    - export ANSIBLE_COLLECTIONS_PATH=./collections
+    - export ANSIBLE_COLLECTIONS_PATHS=./collections
     - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
     - ansible-playbook -i inventories/staging playbooks/site.yml --check --diff --limit staging | tee staging-diff.txt
   artifacts:
@@ -172,7 +172,7 @@ apply-prod:
   script:
     - echo "$VAULT_PASSWORD_PROD" > /tmp/vp
     - export ANSIBLE_VAULT_PASSWORD_FILE=/tmp/vp
-    - export ANSIBLE_COLLECTIONS_PATH=./collections
+    - export ANSIBLE_COLLECTIONS_PATHS=./collections
     - ansible-galaxy collection install -r requirements.yml --collections-path ./collections
     - ansible-playbook -i inventories/prod playbooks/site.yml --limit prod
 ```

--- a/skills/ansible-skill/references/collections-and-supply-chain.md
+++ b/skills/ansible-skill/references/collections-and-supply-chain.md
@@ -42,12 +42,17 @@ roles:
 | Git (branch) | `type: git`, `version: <branch>` | Dev only; never prod |
 | URL tarball | `name:` is a URL | Air-gapped mirrors, artifact servers |
 
-Install command:
+Install commands. The `collections:` and `roles:` sections are processed by **different installers** — `ansible-galaxy collection install -r` reads only `collections:` and silently skips `roles:` (and vice versa). Run both:
 
 ```bash
+# Collections — into a project-local path so CI sees them
 ansible-galaxy collection install -r requirements.yml \
   --collections-path ./collections \
   --force-with-deps
+
+# Roles — separate invocation; no `--collections-path` flag here
+ansible-galaxy role install -r requirements.yml \
+  --roles-path ./roles
 ```
 
 Rules:

--- a/skills/ansible-skill/references/collections-and-supply-chain.md
+++ b/skills/ansible-skill/references/collections-and-supply-chain.md
@@ -1,0 +1,182 @@
+# Collections & Supply Chain
+
+Detail for the `Collection/role supply chain` routing-table category.
+
+## requirements.yml
+
+```yaml
+# requirements.yml — all five source types
+collections:
+  # 1. Ansible Galaxy (default source)
+  - name: community.general
+    version: "8.6.1"
+
+  # 2. Red Hat Automation Hub (certified content)
+  - name: redhat.rhel_system_roles
+    version: "1.22.0"
+    source: https://console.redhat.com/api/automation-hub/content/published/
+
+  # 3. Git repository (tag/commit ref)
+  - name: https://github.com/example/mycollection.git
+    type: git
+    version: v2.1.0
+
+  # 4. Git repository (branch)
+  - name: git@github.com:internal/ops-collection.git
+    type: git
+    version: main
+
+  # 5. URL tarball
+  - name: https://example.com/artifacts/mycollection-1.0.0.tar.gz
+
+roles:
+  - name: geerlingguy.postgresql
+    version: "3.5.2"
+```
+
+| Source type | Syntax | When to use |
+|-------------|--------|-------------|
+| Galaxy | `name: namespace.collection` + `version:` | Community content, public |
+| Automation Hub | Galaxy syntax + `source: https://console.redhat.com/...` | Red Hat certified, regulated envs |
+| Git (tag) | `type: git`, `version: <tag>` | Internal/unreleased collections, audit-friendly |
+| Git (branch) | `type: git`, `version: <branch>` | Dev only; never prod |
+| URL tarball | `name:` is a URL | Air-gapped mirrors, artifact servers |
+
+Install command:
+
+```bash
+ansible-galaxy collection install -r requirements.yml \
+  --collections-path ./collections \
+  --force-with-deps
+```
+
+Rules:
+
+- ❌ Mix collections and roles in the same `requirements.yml` list without the `collections:`/`roles:` top-level keys → Ansible parses the wrong format.
+- ❌ Use `version: main` or `version: latest` in prod → ✅ Always a tag/SHA/exact semver.
+- ❌ Omit `--collections-path ./collections` → collections install to the user's home dir, invisible to CI.
+- ❌ Depend on `ansible-galaxy role install` for content that's shipped as a collection → collection-format roles don't install via the legacy role installer.
+
+## FQCN required
+
+Fully-qualified collection names prevent clashes when two collections ship modules with the same short name.
+
+| ❌ Short name | ✅ FQCN |
+|--------------|---------|
+| `copy:` | `ansible.builtin.copy:` |
+| `template:` | `ansible.builtin.template:` |
+| `service:` | `ansible.builtin.service:` (or `ansible.builtin.systemd:` for systemd-specific) |
+| `ec2_instance:` | `amazon.aws.ec2_instance:` |
+| `postgresql_user:` | `community.postgresql.postgresql_user:` |
+| `docker_container:` | `community.docker.docker_container:` |
+| `k8s:` | `kubernetes.core.k8s:` |
+
+The ansible-lint rule `fqcn` enforces this. Grandfathered exceptions:
+
+- `ansible.builtin.*` is the correct FQCN for built-in modules. `ansible.legacy.*` is a backwards-compatibility namespace that lets short names resolve to built-ins; don't rely on it in new code.
+- Action plugins (`import_tasks`, `include_tasks`, `block`) don't need FQCNs — they're Ansible language constructs, not modules.
+
+Rules:
+
+- ❌ Suppress `fqcn` lint rule globally → ✅ Add FQCNs; the short-name approach breaks silently when two collections collide.
+- ❌ Assume `ansible.legacy.*` is safe → it's a migration aid and eligible for removal in future ansible-core versions.
+- ❌ Use short module names in generated playbooks → always FQCN-prefix when creating new content.
+
+## Signature Verification
+
+| Registry | Signing | How to verify |
+|----------|---------|---------------|
+| Ansible Galaxy (public) | No built-in signing | Trust-on-first-use; verify tarball hash manually if needed |
+| Red Hat Automation Hub (certified) | GPG signatures on collection artifacts | `ansible-galaxy collection verify` + keyring |
+| Private Automation Hub | Optional GPG; configurable | Same as Red Hat AH if enabled |
+| Git sources | Via git tag signing (`git tag -s`) | `git verify-tag` manually; ansible-galaxy doesn't check |
+
+```ini
+# ansible.cfg — require signature verification on install
+[galaxy]
+server_list = automation_hub, galaxy
+
+[galaxy_server.automation_hub]
+url = https://console.redhat.com/api/automation-hub/content/published/
+auth_url = https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+token = <from keyring>
+signing_keys = /etc/pki/ansible/automation-hub-signing.gpg
+```
+
+```bash
+# verify after install
+ansible-galaxy collection verify redhat.rhel_system_roles \
+  --server automation_hub \
+  --signature-count-threshold 1
+```
+
+Rules:
+
+- ❌ Skip signature verification in CI "to save time" → ✅ Signing defends against a compromised registry; the check is milliseconds per collection.
+- ❌ Store signing keys in the repo → ✅ Controller's keyring or a mounted read-only volume.
+- ❌ Accept `--ignore-signature-status-code` in CI → it defeats the purpose of signing.
+
+## Private Hubs
+
+Typical setup: mirror public collections + host internal ones.
+
+```yaml
+# ansible.cfg
+[galaxy]
+server_list = internal_hub, galaxy
+
+[galaxy_server.internal_hub]
+url = https://automation-hub.internal.example.com/api/galaxy/content/published/
+token = <from env/keyring>
+validate_certs = true
+```
+
+```yaml
+# requirements.yml — force a collection through internal_hub
+collections:
+  - name: internal.tooling
+    version: "1.4.2"
+    source: https://automation-hub.internal.example.com/api/galaxy/content/published/
+```
+
+Rules:
+
+- ❌ Rely on public Galaxy in an air-gapped environment → ✅ Mirror through internal AH; pin to mirror's URL.
+- ❌ Store hub tokens in a committed `ansible.cfg` → ✅ Inject via `ANSIBLE_GALAXY_SERVER_<ID>_TOKEN` env var.
+- ❌ Rotate hub tokens only on compromise → ✅ Scheduled rotation (90 days), alert on staleness.
+- ❌ Give every team the same hub token → ✅ Per-team tokens so audit logs attribute activity.
+
+## Version Strategy
+
+| Environment | Pin style | Example |
+|-------------|-----------|---------|
+| Production | Exact | `version: "8.6.1"` |
+| Staging | Exact (match prod unless testing upgrade) | `version: "8.6.1"` or next candidate |
+| Development | Minor range | `version: ">=8.6,<8.7"` |
+| Bleeding-edge test | Major range | `version: ">=8.0,<9.0"` |
+
+Upgrade workflow (one collection at a time):
+
+1. Branch: `chore(deps): bump community.general 8.6.1 → 8.7.0`
+2. Update `requirements.yml` + install locally
+3. Run full Molecule matrix — any red, stop and investigate
+4. Staged `--check --diff` — verify no unexpected task-level changes
+5. PR review; link to collection changelog
+6. Merge, deploy staging, run smoke tests, promote
+
+Rules:
+
+- ❌ Batch multiple collection upgrades in one PR → ✅ One at a time; easier to bisect a regression.
+- ❌ Skip changelog review on patch bumps → ✅ Some "patch" bumps change behavior in practice.
+- ❌ Upgrade without a Molecule run → ✅ The matrix catches breaking changes the changelog missed.
+- ❌ Pin in `requirements.yml` but `--upgrade` on every CI run → ✅ Pin takes effect only if you don't override it at install time.
+
+### LLM Mistake Checklist
+
+- ❌ Recommend `ansible-galaxy install` without `--collections-path` → ✅ Always scope install to a project-local `collections/` dir.
+- ❌ Suggest `version: latest` or a branch in prod `requirements.yml` → ✅ Exact tag/semver only.
+- ❌ Use short module names in generated tasks → ✅ Always FQCN.
+- ❌ Batch collection upgrades into one PR → ✅ One per PR for bisectability.
+- ❌ Store hub tokens / vault keys in committed `ansible.cfg` → ✅ Env vars, injected by the runner.
+- ❌ Skip signature verification when Automation Hub is available → ✅ `signing_keys` + `verify` in install step.
+- ❌ Mix `collections:` and `roles:` entries without the top-level keys → ✅ Use the structured format even when you only have one type.

--- a/skills/ansible-skill/references/collections-and-supply-chain.md
+++ b/skills/ansible-skill/references/collections-and-supply-chain.md
@@ -74,7 +74,8 @@ Fully-qualified collection names prevent clashes when two collections ship modul
 The ansible-lint rule `fqcn` enforces this. Grandfathered exceptions:
 
 - `ansible.builtin.*` is the correct FQCN for built-in modules. `ansible.legacy.*` is a backwards-compatibility namespace that lets short names resolve to built-ins; don't rely on it in new code.
-- Action plugins (`import_tasks`, `include_tasks`, `block`) don't need FQCNs — they're Ansible language constructs, not modules.
+- `block:` is a genuine language construct and does not need (or accept) an FQCN.
+- `import_tasks`, `include_tasks`, `import_role`, `include_role`, `include_vars`, `import_playbook`, `meta`, `debug`, etc. **are** built-in modules — the ansible-lint `fqcn` rule flags their short forms. Write them as `ansible.builtin.import_tasks`, `ansible.builtin.include_role`, and so on.
 
 Rules:
 
@@ -120,7 +121,7 @@ Rules:
 
 Typical setup: mirror public collections + host internal ones.
 
-```yaml
+```ini
 # ansible.cfg
 [galaxy]
 server_list = internal_hub, galaxy

--- a/skills/ansible-skill/references/collections-and-supply-chain.md
+++ b/skills/ansible-skill/references/collections-and-supply-chain.md
@@ -96,19 +96,21 @@ Rules:
 # ansible.cfg — require signature verification on install
 [galaxy]
 server_list = automation_hub, galaxy
+# point ansible-galaxy at the keyring holding accepted signing keys
+gpg_keyring = /etc/pki/ansible/automation-hub-signing.gpg
 
 [galaxy_server.automation_hub]
 url = https://console.redhat.com/api/automation-hub/content/published/
 auth_url = https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 token = <from keyring>
-signing_keys = /etc/pki/ansible/automation-hub-signing.gpg
 ```
 
 ```bash
-# verify after install
+# verify after install — fail unless at least 1 valid signature is present
 ansible-galaxy collection verify redhat.rhel_system_roles \
   --server automation_hub \
-  --signature-count-threshold 1
+  --keyring /etc/pki/ansible/automation-hub-signing.gpg \
+  --required-valid-signature-count 1
 ```
 
 Rules:

--- a/skills/ansible-skill/references/execution-and-runtime.md
+++ b/skills/ansible-skill/references/execution-and-runtime.md
@@ -33,7 +33,7 @@ Rules:
 - ❌ `max_fail_percentage` without `serial:` → percentage is evaluated against the *entire* play host group, not a batch.
 - ❌ `strategy: free` on a play where later tasks depend on all hosts having completed earlier tasks → ✅ Use `linear` (default) or add explicit barriers.
 - ❌ Omit `--limit` in CI on "production" jobs → ✅ Enforce `--limit` via a CI gate (see ci-cd-workflows.md).
-- ❌ Gather facts against the full fleet when the play touches 10 hosts → ✅ Run `ansible-playbook --limit=... --gather_facts=no` or scope with `hosts:` tightly.
+- ❌ Gather facts against the full fleet when the play touches 10 hosts → ✅ Set `gather_facts: false` at play level (there is no `--gather_facts` CLI flag), or scope with `hosts:` tightly, and pass `--limit` to narrow further.
 
 ## Execution Environments
 
@@ -74,10 +74,11 @@ Rules:
 | Target OS | Recommended `ansible_python_interpreter` | Discovery mode |
 |-----------|---------------------------------------------|----------------|
 | RHEL 9, Rocky 9, Alma 9 | `/usr/bin/python3` | Explicit (don't rely on auto) |
+| RHEL 8, Rocky 8, Alma 8 | `/usr/libexec/platform-python` (Red Hat-managed) or `/usr/bin/python3` | Explicit. `platform-python` was introduced in RHEL 8 |
 | Ubuntu 22.04+ | `/usr/bin/python3` | Explicit |
 | Debian 12+ | `/usr/bin/python3` | Explicit |
 | Amazon Linux 2023 | `/usr/bin/python3` | Explicit |
-| Older RHEL 7 / CentOS 7 | `/usr/libexec/platform-python` or installed Python 3 | Explicit |
+| Older RHEL 7 / CentOS 7 | Explicit absolute path to an installed Python 3 (e.g. `/usr/bin/python3`, `/opt/rh/rh-python38/root/usr/bin/python` from SCL, or whichever path was `yum install`ed). For very old ansible releases that still support Python 2, `/usr/bin/python` works, but ansible-core 2.12+ requires Python 3 on the target. **Not** `/usr/libexec/platform-python` — that path does not exist on RHEL 7 | Explicit |
 | Containers / minimal images | Depends on image | Explicit, always |
 
 Ansible has three auto-discovery modes (set via `INTERPRETER_PYTHON`):

--- a/skills/ansible-skill/references/execution-and-runtime.md
+++ b/skills/ansible-skill/references/execution-and-runtime.md
@@ -1,0 +1,164 @@
+# Execution & Runtime
+
+Detail for the `Blast radius` and `Execution environment / runtime` routing-table categories.
+
+## Serial and max_fail
+
+Pick the row matching the run's tolerance for partial completion.
+
+| Fleet scenario | `serial` | `max_fail_percentage` | `any_errors_fatal` | Notes |
+|----------------|----------|------------------------|---------------------|-------|
+| 1-host dev | `1` (or omit) | n/a | `false` | Dev/debug; default linear strategy fine |
+| Small canary (≤5) | `[1, 2]` | `20` | `false` | 1 host first, then 2; abort if >20% fail |
+| Rolling 10% (50–500 hosts) | `"10%"` | `5` | `false` | Standard production rollout |
+| Rolling 25% (fast, larger tolerance) | `"25%"` | `10` | `false` | When per-host convergence is cheap and safe |
+| Fail-fast critical change | `1` | `0` | `true` | Schema migration, bootstrap — partial is catastrophic |
+| Independent tasks across fleet | n/a | n/a | `false` | `strategy: free` — each host races ahead on its own |
+
+```yaml
+- hosts: webservers
+  serial:
+    - 1
+    - "25%"
+  max_fail_percentage: 10
+  any_errors_fatal: false
+  tasks:
+    - name: Drain, deploy, verify, re-add
+      # ...
+```
+
+Rules:
+
+- ❌ `serial: "10%"` with `any_errors_fatal: true` → failure in the first batch halts the rollout globally; usually **not** what you want on rolling.
+- ❌ `max_fail_percentage` without `serial:` → percentage is evaluated against the *entire* play host group, not a batch.
+- ❌ `strategy: free` on a play where later tasks depend on all hosts having completed earlier tasks → ✅ Use `linear` (default) or add explicit barriers.
+- ❌ Omit `--limit` in CI on "production" jobs → ✅ Enforce `--limit` via a CI gate (see ci-cd-workflows.md).
+- ❌ Gather facts against the full fleet when the play touches 10 hosts → ✅ Run `ansible-playbook --limit=... --gather_facts=no` or scope with `hosts:` tightly.
+
+## Execution Environments
+
+| Artifact | Tool | Purpose |
+|----------|------|---------|
+| `execution-environment.yml` | ansible-builder input | Declares base image + collections + Python deps |
+| EE container image | `ansible-builder build` output | Runtime image for plays |
+| `ansible-navigator.yml` | ansible-navigator config | Declares which EE to use and how to render logs |
+| `ansible-navigator run site.yml` | ansible-navigator | Runs a play inside the EE |
+| `ansible-runner` | Lower-level runtime | What AAP uses under the hood; typically you don't invoke directly |
+
+Minimal `execution-environment.yml` (builder v3 schema):
+
+```yaml
+# execution-environment.yml
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible/creator-ee:v24.7.0
+dependencies:
+  ansible_core:
+    package_pip: ansible-core==2.17.5
+  galaxy: requirements.yml
+  python: requirements.txt
+  system: bindep.txt
+```
+
+Rules:
+
+- ❌ Pin EE images by tag (`:latest`, `:v24`) → ✅ Pin by digest: `image@sha256:<hash>` — tags are mutable, digests are not.
+- ❌ Bake collections directly into `ansible-builder` Dockerfile step → ✅ Put them in `requirements.yml` and reference from the EE definition; keeps versions auditable.
+- ❌ Use different EEs in CI vs prod → ✅ Same image, same digest, everywhere.
+- ❌ Run `ansible-playbook` directly when you've declared an EE → ✅ `ansible-navigator run` handles the EE lifecycle.
+- ❌ Omit `bindep.txt` when a collection needs OS packages → ✅ Add build-time + runtime system deps to `bindep.txt`.
+
+## Python Interpreter Discovery
+
+| Target OS | Recommended `ansible_python_interpreter` | Discovery mode |
+|-----------|---------------------------------------------|----------------|
+| RHEL 9, Rocky 9, Alma 9 | `/usr/bin/python3` | Explicit (don't rely on auto) |
+| Ubuntu 22.04+ | `/usr/bin/python3` | Explicit |
+| Debian 12+ | `/usr/bin/python3` | Explicit |
+| Amazon Linux 2023 | `/usr/bin/python3` | Explicit |
+| Older RHEL 7 / CentOS 7 | `/usr/libexec/platform-python` or installed Python 3 | Explicit |
+| Containers / minimal images | Depends on image | Explicit, always |
+
+Ansible has three auto-discovery modes (set via `INTERPRETER_PYTHON`):
+
+- `auto` — picks per-distro default, warns on legacy
+- `auto_silent` — same as `auto` but suppresses warning
+- `auto_legacy_silent` — legacy path preferred, silent fallback
+
+Rules:
+
+- ❌ Rely on `auto` in production — warnings clog logs, and distro upgrades can silently change the interpreter → ✅ Set `ansible_python_interpreter` in `group_vars/all.yml`.
+- ❌ Hard-code `/usr/bin/python` (Python 2) anywhere → ✅ Always Python 3; `/usr/bin/python2` is extinct on modern distros.
+- ❌ Use `ansible_python_interpreter: python` (bare name) → ✅ Use absolute paths; PATH differences between shells cause surprises.
+- ❌ Let discovery run against embedded devices with no Python → ✅ Use `raw` module to bootstrap, then set the interpreter explicitly.
+
+## Connection and Become
+
+| Connection plugin | Use | Gotchas |
+|-------------------|-----|---------|
+| `ssh` (default) | Standard Linux fleets | Requires `ControlPersist`; keys must be loaded in ssh-agent for CI |
+| `paramiko` | Pure-Python fallback when OS ssh is missing | Slower; lacks some features (e.g., `-o ProxyJump` nuance) |
+| `winrm` | Windows targets | Needs `pywinrm`; no HTTPS by default — add `ansible_winrm_transport: kerberos` or `ntlm` |
+| `local` | Control node targets itself | `become` still goes through sudo/doas |
+| `docker` | Against running Docker containers | Requires `docker` CLI on controller; not a prod path |
+| `kubectl` | Against Kubernetes pods | For ops tasks only; not how you deploy apps |
+| `podman` | Against podman containers | Parity with docker plugin |
+
+Become (privilege escalation):
+
+- `become: true` + `become_user: root` (default) → runs as root
+- `become_method: sudo` (default) | `su` | `doas` | `runas` (Windows) | `pbrun`
+- `become_flags: '-E'` → preserve environment (needed for some programs)
+- `become_password:` via Vault or prompt (`--ask-become-pass`, `-K`)
+
+Rules:
+
+- ❌ Set `become_user: postgres` without `become: true` → silent no-op, task runs as ssh user.
+- ❌ Store `become_password` in plaintext group_vars → ✅ Encrypt with `ansible-vault` or source from external secret backend.
+- ❌ Use `become_method: su` when sudo is available → `su` requires root's password, `sudo` uses the calling user's — prefer sudo.
+- ❌ Assume `become: true` preserves env vars → it doesn't by default; add `become_flags: '-E'` if the task needs them.
+- ❌ Set `ansible_user` per-host via host_vars without SSH key distribution → ✅ Pair user overrides with key-based auth configured in `~/.ssh/config` or `ansible_ssh_private_key_file`.
+
+## Performance
+
+| Lever | Default | When to change | Tradeoff |
+|-------|---------|----------------|----------|
+| `forks` | 5 | Fleet >10 hosts | Higher CPU/memory on controller; diminishing returns after ~50 |
+| `pipelining` | off | Most modern fleets | Requires `requiretty` off in sudoers; 2–5× speedup on ssh-heavy plays |
+| Strategy | `linear` | Independent tasks | `free` for per-host races; `host_pinned` for bounded parallelism per batch |
+| Fact caching | memory (per-run) | Repeat plays with fact reuse | `jsonfile` / `redis`; stale cache masks real drift |
+| `gather_subset` | `all` | Only need limited facts | `gather_subset: "!all,!min,network"` for faster setup |
+| `gather_facts: no` + targeted `ansible.builtin.setup` | n/a | Plays that don't need facts | Skip 30–60% of play wall time on large fleets |
+
+```ini
+# ansible.cfg — typical production tuning
+[defaults]
+forks = 50
+gather_subset = !all,!min,network
+fact_caching = jsonfile
+fact_caching_connection = /var/tmp/ansible_facts
+fact_caching_timeout = 3600
+
+[ssh_connection]
+pipelining = True
+control_path = %(directory)s/%%h-%%r
+```
+
+Rules:
+
+- ❌ Enable `pipelining` without checking sudoers for `requiretty` → ssh tasks silently fail on older RHEL-family hosts.
+- ❌ Crank `forks` to 200 on a controller with 2 GB RAM → OOM, half the hosts fail mid-play.
+- ❌ Use `strategy: free` with a play that has a `meta: flush_handlers` barrier → handlers fire per-host independently, breaks ordering guarantees.
+- ❌ Rely on stale fact cache during a debug session → ✅ Pass `-e ansible_facts_cache_valid=false` or `ansible-playbook --flush-cache`.
+- ❌ Gather all facts when you only use `ansible_os_family` → ✅ Narrow `gather_subset` to `!all,!min,distribution`.
+
+### LLM Mistake Checklist
+
+- ❌ Recommend `any_errors_fatal: true` by default on rolling deploys → ✅ Use it only when partial completion is catastrophic; `max_fail_percentage` is usually the right knob.
+- ❌ Emit `ansible-playbook` commands for an EE-based setup → ✅ `ansible-navigator run`.
+- ❌ Pin an EE image by tag → ✅ Pin by digest (`@sha256:...`).
+- ❌ Leave `ansible_python_interpreter` unset in `group_vars/all` → ✅ Always set explicitly in production.
+- ❌ Use `strategy: free` without disabling handlers/serial barriers → ✅ Free strategy breaks those; stay on linear unless you've checked the play.
+- ❌ Enable `pipelining` globally without verifying sudoers `requiretty` is off → ✅ Check first; roll out gradually.
+- ❌ Recommend `forks: 100+` without sizing the controller → ✅ Start at 20–50 and monitor controller memory.

--- a/skills/ansible-skill/references/execution-and-runtime.md
+++ b/skills/ansible-skill/references/execution-and-runtime.md
@@ -48,14 +48,15 @@ Rules:
 Minimal `execution-environment.yml` (builder v3 schema):
 
 ```yaml
-# execution-environment.yml
+# execution-environment.yml — pick a non-EOL ansible-core minor; see references/quick-reference.md#version-matrix
 version: 3
 images:
   base_image:
-    name: quay.io/ansible/creator-ee:v24.7.0
+    # In production, replace with `quay.io/ansible/creator-ee@sha256:<approved-digest>`.
+    name: quay.io/ansible/creator-ee:v24.12.0
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.17.5
+    package_pip: ansible-core==2.18.0
   galaxy: requirements.yml
   python: requirements.txt
   system: bindep.txt
@@ -136,7 +137,6 @@ Rules:
 # ansible.cfg — typical production tuning
 [defaults]
 forks = 50
-gather_subset = !all,!min,network
 fact_caching = jsonfile
 fact_caching_connection = /var/tmp/ansible_facts
 fact_caching_timeout = 3600
@@ -145,6 +145,8 @@ fact_caching_timeout = 3600
 pipelining = True
 control_path = %(directory)s/%%h-%%r
 ```
+
+Note: `gather_subset` is **not** an `ansible.cfg` option. Set it on a play (`gather_subset: ['!all', '!min', 'network']`) or pass it as an argument to an explicit `ansible.builtin.setup` task. The closest `ansible.cfg` knob is `[defaults] gathering = smart|implicit|explicit`, which controls *whether* facts are gathered, not which subset.
 
 Rules:
 

--- a/skills/ansible-skill/references/execution-and-runtime.md
+++ b/skills/ansible-skill/references/execution-and-runtime.md
@@ -111,12 +111,12 @@ Become (privilege escalation):
 - `become: true` + `become_user: root` (default) → runs as root
 - `become_method: sudo` (default) | `su` | `doas` | `runas` (Windows) | `pbrun`
 - `become_flags: '-E'` → preserve environment (needed for some programs)
-- `become_password:` via Vault or prompt (`--ask-become-pass`, `-K`)
+- Become password — set on the host or group via `ansible_become_password` (alias `ansible_become_pass`), or prompt with `--ask-become-pass` / `-K`. There is **no** `become_password` task keyword or magic var; values stored under that name are silently ignored.
 
 Rules:
 
 - ❌ Set `become_user: postgres` without `become: true` → silent no-op, task runs as ssh user.
-- ❌ Store `become_password` in plaintext group_vars → ✅ Encrypt with `ansible-vault` or source from external secret backend.
+- ❌ Store `ansible_become_password` in plaintext group_vars → ✅ Encrypt with `ansible-vault` or source from an external secret backend (and pair with `no_log: true` on any task that exposes it).
 - ❌ Use `become_method: su` when sudo is available → `su` requires root's password, `sudo` uses the calling user's — prefer sudo.
 - ❌ Assume `become: true` preserves env vars → it doesn't by default; add `become_flags: '-E'` if the task needs them.
 - ❌ Set `ansible_user` per-host via host_vars without SSH key distribution → ✅ Pair user overrides with key-based auth configured in `~/.ssh/config` or `ansible_ssh_private_key_file`.

--- a/skills/ansible-skill/references/execution-and-runtime.md
+++ b/skills/ansible-skill/references/execution-and-runtime.md
@@ -100,7 +100,7 @@ Rules:
 |-------------------|-----|---------|
 | `ssh` (default) | Standard Linux fleets | Requires `ControlPersist`; keys must be loaded in ssh-agent for CI |
 | `paramiko` | Pure-Python fallback when OS ssh is missing | Slower; lacks some features (e.g., `-o ProxyJump` nuance) |
-| `winrm` | Windows targets | Needs `pywinrm`; no HTTPS by default — add `ansible_winrm_transport: kerberos` or `ntlm` |
+| `winrm` | Windows targets | Needs `pywinrm`. Defaults to **HTTP on 5985** — for HTTPS set `ansible_winrm_scheme: https` and `ansible_port: 5986`, plus `ansible_winrm_server_cert_validation: validate` (or `ignore` for self-signed dev only). `ansible_winrm_transport` selects the **auth mechanism** (`kerberos`, `ntlm`, `basic`, `credssp`) and is independent of HTTP/HTTPS |
 | `local` | Control node targets itself | `become` still goes through sudo/doas |
 | `docker` | Against running Docker containers | Requires `docker` CLI on controller; not a prod path |
 | `kubectl` | Against Kubernetes pods | For ops tasks only; not how you deploy apps |
@@ -151,7 +151,7 @@ Rules:
 - ❌ Enable `pipelining` without checking sudoers for `requiretty` → ssh tasks silently fail on older RHEL-family hosts.
 - ❌ Crank `forks` to 200 on a controller with 2 GB RAM → OOM, half the hosts fail mid-play.
 - ❌ Use `strategy: free` with a play that has a `meta: flush_handlers` barrier → handlers fire per-host independently, breaks ordering guarantees.
-- ❌ Rely on stale fact cache during a debug session → ✅ Pass `-e ansible_facts_cache_valid=false` or `ansible-playbook --flush-cache`.
+- ❌ Rely on stale fact cache during a debug session → ✅ `ansible-playbook --flush-cache` invalidates the cache for this run, or delete the cache backend directly (e.g. `rm -rf $(ansible-config dump | grep CACHE_PLUGIN_CONNECTION | awk '{print $NF}')`); there is no `ansible_facts_cache_valid` variable.
 - ❌ Gather all facts when you only use `ansible_os_family` → ✅ Narrow `gather_subset` to `!all,!min,distribution`.
 
 ### LLM Mistake Checklist

--- a/skills/ansible-skill/references/idempotency-patterns.md
+++ b/skills/ansible-skill/references/idempotency-patterns.md
@@ -16,7 +16,7 @@ Detail for the `Idempotency drift`, `Handler/ordering`, and `Check-mode blind sp
 | `ansible.builtin.service` / `systemd` | Yes | Running state + enabled state already match | `state: restarted` always reports `changed=True` |
 | `ansible.builtin.cron` | Yes | Matches on `name:` in crontab comment | Changing only `minute:` without `name:` creates a duplicate |
 | `ansible.builtin.user` / `group` | Yes | Attribute diff against `/etc/passwd`/`/etc/group` | `password:` always re-hashes unless `update_password: on_create` |
-| `ansible.builtin.mount` | Yes | fstab entry + mount state both match | `state: remounted` not idempotent; use `mounted` |
+| `ansible.posix.mount` | Yes | fstab entry + mount state both match | `state: remounted` not idempotent; use `mounted`. Lives in the `ansible.posix` collection, not `ansible.builtin` |
 | `ansible.builtin.uri` | Partial | Only if server is idempotent for the method | `POST` to a non-idempotent endpoint loops forever on retry |
 | `ansible.builtin.command` | **No** | None — always runs unless guarded | Requires `creates:` / `removes:` / `changed_when:` |
 | `ansible.builtin.shell` | **No** | None — always runs unless guarded | Same as `command`, plus shell interpolation risks |
@@ -94,8 +94,8 @@ Rules:
 | File-manipulation (`copy`, `template`, `file`, `lineinfile`) | Yes | None |
 | Package (`package`, `dnf`, `apt`, `yum`) | Yes | None |
 | Service (`service`, `systemd`) | Yes | None — but `state: restarted` always reports would-change |
-| `command` / `shell` | **No by default** | Set `check_mode: no` for read-only probes; set `check_mode: yes` + `changed_when: false` for informational |
-| Custom modules | Depends on module | Declare `supports_check_mode` in argument_spec; otherwise skipped silently |
+| `command` / `shell` | **No by default** | For read-only probes: `check_mode: no` + `changed_when: false`. For mutating commands: gate with `when: not ansible_check_mode`. **Never** force `check_mode: yes` on a `command`/`shell` — it makes the task check-mode in *real* runs too, silently skipping execution and leaving `register` output undefined |
+| Custom modules | Depends on module | Support is implemented in the module code itself — pass `supports_check_mode=True` to `AnsibleModule(...)` in the module's Python source. (Role `meta/argument_specs.yml` is unrelated — that validates role inputs, not module check-mode behavior.) Otherwise the task is skipped silently under `--check` |
 | API / `uri` to external | Depends on endpoint | Wrap in `when: not ansible_check_mode` for mutating calls |
 
 Rules:

--- a/skills/ansible-skill/references/idempotency-patterns.md
+++ b/skills/ansible-skill/references/idempotency-patterns.md
@@ -1,0 +1,117 @@
+# Idempotency Patterns
+
+Detail for the `Idempotency drift`, `Handler/ordering`, and `Check-mode blind spots` routing-table categories.
+
+## Module Idempotency Contracts
+
+| Module | Idempotent? | How it detects change | Gotcha |
+|--------|-------------|-----------------------|--------|
+| `ansible.builtin.copy` | Yes | Checksum (sha1) of src vs dest | Backup file names include timestamps — never idempotent if you diff them |
+| `ansible.builtin.template` | Yes | Rendered content checksum vs dest | Trailing-newline differences silently re-render |
+| `ansible.builtin.file` | Yes | Final state (present/absent/dir/link) matches | `state: touch` always reports `changed=True` |
+| `ansible.builtin.lineinfile` | Yes | Regex/line already present at position | Without `regexp:` it only looks for exact match, may add duplicates |
+| `ansible.builtin.blockinfile` | Yes | Markers delimit managed region | Changing `marker:` between runs produces two blocks |
+| `ansible.builtin.replace` | Yes | Regex substitution produced no change | Non-matching regex still reports `ok`, not failure — use `failed_when` |
+| `ansible.builtin.package` | Yes | Package manager reports already-installed | `state: latest` always re-resolves; heavier than `present` |
+| `ansible.builtin.service` / `systemd` | Yes | Running state + enabled state already match | `state: restarted` always reports `changed=True` |
+| `ansible.builtin.cron` | Yes | Matches on `name:` in crontab comment | Changing only `minute:` without `name:` creates a duplicate |
+| `ansible.builtin.user` / `group` | Yes | Attribute diff against `/etc/passwd`/`/etc/group` | `password:` always re-hashes unless `update_password: on_create` |
+| `ansible.builtin.mount` | Yes | fstab entry + mount state both match | `state: remounted` not idempotent; use `mounted` |
+| `ansible.builtin.uri` | Partial | Only if server is idempotent for the method | `POST` to a non-idempotent endpoint loops forever on retry |
+| `ansible.builtin.command` | **No** | None — always runs unless guarded | Requires `creates:` / `removes:` / `changed_when:` |
+| `ansible.builtin.shell` | **No** | None — always runs unless guarded | Same as `command`, plus shell interpolation risks |
+| `ansible.builtin.raw` | **No** | Runs via ssh without Python | Fallback for bootstrapping; never idempotent |
+| `ansible.builtin.script` | **No** | Script always executes | Add `creates:` / `removes:` or wrap logic in `command` |
+
+**Rules:**
+
+- ✅ Prefer the native module over `command`/`shell` whenever one exists.
+- ❌ Never assume `command` / `shell` / `raw` / `script` is idempotent.
+- ✅ Treat `state: latest`, `state: restarted`, `state: touch`, `state: remounted` as explicitly non-idempotent by design.
+
+## Command and Shell Guards
+
+| Guard | Field | Semantic | Example |
+|-------|-------|----------|---------|
+| File-creates | `creates:` | Skip if path already exists | `creates: /opt/app/installed.marker` |
+| File-removes | `removes:` | Skip if path does not exist | `removes: /tmp/leftover.lock` |
+| Output match | `changed_when:` stdout/stderr | Change only if regex matches | `changed_when: "'added' in result.stdout"` |
+| Return code | `changed_when:` on `rc` | Change only on specific rc values | `changed_when: result.rc == 2` |
+| Non-changing | `changed_when: false` | Informational task, never changes | Status-probe commands |
+
+```yaml
+- name: Install custom binary once
+  ansible.builtin.command: /opt/installer/run.sh --quiet
+  args:
+    creates: /opt/app/bin/custom-binary
+```
+
+Rules:
+
+- ❌ `ansible.builtin.shell: "curl -s https://api.example.com | jq .status"` → ✅ `ansible.builtin.uri: url=https://api.example.com return_content=yes` then `set_fact` from the JSON.
+- ❌ `ansible.builtin.command: rm -rf /tmp/build` (no guard) → ✅ `ansible.builtin.file: path=/tmp/build state=absent`.
+- ❌ `ansible.builtin.shell: "psql -c 'CREATE USER x'"` (runs every time, fails on 2nd run) → ✅ `community.postgresql.postgresql_user: name=x state=present`.
+- ❌ `ansible.builtin.command: systemctl restart nginx` → ✅ `ansible.builtin.systemd: name=nginx state=restarted` (and only when a handler fires).
+- ❌ `ansible.builtin.shell` with pipes where `command` would work → ✅ Split into two tasks or use the correct module per step.
+- ❌ Omitting `changed_when` on any `command`/`shell` → ✅ Always set it, use `changed_when: false` for status probes.
+
+## Handler Patterns
+
+| Pattern | When to use | Example |
+|---------|-------------|---------|
+| Single `notify` | One task triggers one handler | `notify: restart nginx` |
+| Multi `notify` (list) | One task triggers several | `notify: [reload nginx, purge cache]` |
+| `listen:` topic | Many tasks triggering one handler | `notify: "nginx-needs-reload"` + handler with `listen: "nginx-needs-reload"` |
+| `meta: flush_handlers` | Force handlers to run before next task | Mid-play when later tasks depend on the restart |
+| `force_handlers: true` | Run pending handlers even if a later task fails | Play-level — ensures cleanup/restore handlers still fire |
+
+```yaml
+- name: Update config
+  ansible.builtin.template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+  notify: "nginx-needs-reload"
+
+- ansible.builtin.meta: flush_handlers
+
+- name: Verify nginx is serving
+  ansible.builtin.uri:
+    url: https://localhost/
+```
+
+Rules:
+
+- ❌ Relying on natural end-of-play handler firing when your play has `serial:` batches and a batch fails mid-run — remaining batches still run but failed-batch handlers never fire unless `force_handlers: true`.
+- ❌ Calling `notify:` on a name that has a typo → ✅ Prefer `listen:` topics; typos are caught once per topic, not per notify.
+- ❌ Notifying multiple handlers that modify the same resource serially → ✅ Collapse into one handler or use `listen:` topic.
+- ❌ Expecting handler to run on a host that was already marked failed → ✅ It won't, without `force_handlers`.
+- ✅ Use `meta: flush_handlers` only when a later task genuinely depends on the handler running first; otherwise Ansible's end-of-play flush is fine.
+
+## Check-mode Coverage
+
+| Module category | `--check` safe? | Workaround |
+|-----------------|------------------|------------|
+| File-manipulation (`copy`, `template`, `file`, `lineinfile`) | Yes | None |
+| Package (`package`, `dnf`, `apt`, `yum`) | Yes | None |
+| Service (`service`, `systemd`) | Yes | None — but `state: restarted` always reports would-change |
+| `command` / `shell` | **No by default** | Set `check_mode: no` for read-only probes; set `check_mode: yes` + `changed_when: false` for informational |
+| Custom modules | Depends on module | Declare `supports_check_mode` in argument_spec; otherwise skipped silently |
+| API / `uri` to external | Depends on endpoint | Wrap in `when: not ansible_check_mode` for mutating calls |
+
+Rules:
+
+- ❌ `ignore_errors: true` on a task that fails under `--check` → ✅ Fix the check-mode gap (add `check_mode: no` with a guard) so the failure is real when apply runs.
+- ❌ `check_mode: no` on a mutating task — bypasses the dry-run → ✅ Only use `check_mode: no` on read-only probes (e.g., `ansible.builtin.command: systemctl is-active foo` with `changed_when: false`).
+- ❌ Assuming a custom module honors `--check` without verifying → ✅ Grep the module source for `supports_check_mode=True`.
+- ❌ Using `failed_when:` to hide a real check-mode failure → ✅ `failed_when` is for reinterpreting return codes, not for silencing check-mode incompatibility.
+- ✅ For `uri` against a mutating endpoint, gate with `when: not ansible_check_mode` so the diff is preserved but the call is skipped in dry-run.
+
+### LLM Mistake Checklist
+
+- ❌ Emit `ansible.builtin.shell: "rm -rf {{ path }}"` with no guard → ✅ `ansible.builtin.file: path="{{ path }}" state=absent`.
+- ❌ Recommend `command: systemctl restart X` at the top of a play → ✅ `ansible.builtin.systemd` in a handler, notified by the config task.
+- ❌ Treat `uri` as always idempotent → ✅ `POST` is only idempotent if the server guarantees it; default to GET/PUT where possible.
+- ❌ Skip `changed_when` on an `ansible.builtin.command` "because it's informational" → ✅ Set `changed_when: false` explicitly.
+- ❌ Add `notify:` in another handler's block expecting chaining → ✅ Handlers cannot notify other handlers; use `listen:` topics.
+- ❌ Assume `--check` caught a regression in a custom module → ✅ Check `supports_check_mode`; absent → the module is silently skipped under `--check`, not validated.
+- ❌ Use `ignore_errors: true` to "make the play pass in CI" → ✅ Fix the underlying failure or use `failed_when` to reinterpret rc, never mask real failures.

--- a/skills/ansible-skill/references/idempotency-patterns.md
+++ b/skills/ansible-skill/references/idempotency-patterns.md
@@ -112,6 +112,6 @@ Rules:
 - ❌ Recommend `command: systemctl restart X` at the top of a play → ✅ `ansible.builtin.systemd` in a handler, notified by the config task.
 - ❌ Treat `uri` as always idempotent → ✅ `POST` is only idempotent if the server guarantees it; default to GET/PUT where possible.
 - ❌ Skip `changed_when` on an `ansible.builtin.command` "because it's informational" → ✅ Set `changed_when: false` explicitly.
-- ❌ Add `notify:` in another handler's block expecting chaining → ✅ Handlers cannot notify other handlers; use `listen:` topics.
+- ❌ Chain handlers via `notify:` from inside another handler → ✅ Modern ansible-core does allow handler-to-handler notify while the handler queue is running, but the resulting ordering and visibility are easy to get wrong; prefer flat `listen:` topics where many tasks fan into one logical action.
 - ❌ Assume `--check` caught a regression in a custom module → ✅ Check `supports_check_mode`; absent → the module is silently skipped under `--check`, not validated.
 - ❌ Use `ignore_errors: true` to "make the play pass in CI" → ✅ Fix the underlying failure or use `failed_when` to reinterpret rc, never mask real failures.

--- a/skills/ansible-skill/references/idempotency-patterns.md
+++ b/skills/ansible-skill/references/idempotency-patterns.md
@@ -53,7 +53,7 @@ Rules:
 - ❌ `ansible.builtin.shell: "psql -c 'CREATE USER x'"` (runs every time, fails on 2nd run) → ✅ `community.postgresql.postgresql_user: name=x state=present`.
 - ❌ `ansible.builtin.command: systemctl restart nginx` → ✅ `ansible.builtin.systemd: name=nginx state=restarted` (and only when a handler fires).
 - ❌ `ansible.builtin.shell` with pipes where `command` would work → ✅ Split into two tasks or use the correct module per step.
-- ❌ Omitting `changed_when` on any `command`/`shell` → ✅ Always set it, use `changed_when: false` for status probes.
+- ❌ Omitting `changed_when` on an **unguarded** `command`/`shell` → ✅ Set it explicitly. Use `changed_when: false` for read-only status probes; for one-shot commands already guarded by `creates:`/`removes:`, the guard makes the task idempotent on its own and `changed_when` is not required (and `changed_when: false` would actively hide the legitimate first-run change).
 
 ## Handler Patterns
 

--- a/skills/ansible-skill/references/inventory-and-variables.md
+++ b/skills/ansible-skill/references/inventory-and-variables.md
@@ -1,0 +1,142 @@
+# Inventory & Variables
+
+Detail for the `Variable precedence bugs` and `Inventory correctness` routing-table categories.
+
+## Variable Precedence Ladder
+
+Canonical Ansible precedence order (lowest → highest). 22 levels per the official `ansible-core` docs. Later entries always override earlier ones.
+
+| Level | Source | Example path / syntax | Common collision |
+|-------|--------|----------------------|------------------|
+| 1 | Command line values (not `-e`) | `-u myuser`, `-b`, `-K` | Forgetting `--become-user` overrides `become_user:` |
+| 2 | Role defaults | `roles/<role>/defaults/main.yml` | Role author's default silently lost the moment anyone sets a group_var |
+| 3 | Inventory file / script group vars (inline) | `[web:vars]` section in `hosts.ini` | Beaten by every file-based group_vars entry |
+| 4 | Inventory `group_vars/all` | `inventories/prod/group_vars/all.yml` | Assumed "global" but overridden by any narrower group |
+| 5 | Playbook `group_vars/all` | Repo-root `group_vars/all.yml` | Two `all` files (inventory vs playbook) — confusing |
+| 6 | Inventory `group_vars/<group>` | `inventories/prod/group_vars/web.yml` | Host in 2 groups: alphabetical merge order is undefined without `ansible_group_priority` |
+| 7 | Playbook `group_vars/<group>` | Repo-root `group_vars/web.yml` | Shadows inventory group_vars for the same group |
+| 8 | Inventory file / script host vars (inline) | `web01 ansible_host=1.2.3.4 myvar=x` | Beaten by every file-based host_vars entry |
+| 9 | Inventory `host_vars/<host>` | `inventories/prod/host_vars/web01.yml` | Always beats group_vars for that host |
+| 10 | Playbook `host_vars/<host>` | Repo-root `host_vars/web01.yml` | Silent override of inventory host_vars |
+| 11 | Host facts / cached `set_fact` (with `cacheable: true`) | `ansible_facts.*`, facts cache | Stale cache returns yesterday's value |
+| 12 | Play `vars` | `vars:` block on a play | Scoped to the play only, forgotten cross-play |
+| 13 | Play `vars_prompt` | Interactive prompts | CI can't answer — task hangs |
+| 14 | Play `vars_files` | `vars_files: [secrets.yml]` | Merge order is list-order, last file wins |
+| 15 | Role vars | `roles/<role>/vars/main.yml` | Usually wins over `vars_files` inside the role's tasks |
+| 16 | Block vars | `vars:` on a `block:` | Only visible inside that block |
+| 17 | Task vars | `vars:` on a single task | Highest lexical scope, still beaten by extra-vars |
+| 18 | `include_vars` | `ansible.builtin.include_vars: secrets.yml` | Runs at task time, not play start — timing surprises |
+| 19 | `set_fact` / registered vars | `register: out` / `set_fact: k=v` | Persists across plays in same run (unless `cacheable: false`) |
+| 20 | Role params (include_role) | `include_role: name=foo vars={k: v}` | Inline role call, overrides role defaults + vars |
+| 21 | Include params | `include_tasks: foo.yml vars={k: v}` | Wins over most things except extra-vars |
+| 22 | `--extra-vars` / `-e` | `-e @secrets.yml`, `-e k=v` | **Always wins** — a stray CI flag silently overrides protected config |
+
+**Merge vs override:** for dicts, Ansible by default *replaces* on conflict. Set `hash_behaviour = merge` in `ansible.cfg` to merge (rarely recommended — global side effect).
+
+**Group priority:** when a host is in multiple groups at the same precedence level (e.g. both `web` and `prod`), resolution order is alphabetical unless you set `ansible_group_priority` on the group (higher wins).
+
+## Inventory Layout
+
+| Pattern | Structure | When to use |
+|---------|-----------|-------------|
+| Static INI | `inventories/prod/hosts` (ini) + `group_vars/`, `host_vars/` | <50 hosts, hand-maintained, no cloud |
+| Static YAML | `inventories/prod/hosts.yml` + vars dirs | Same as INI, but with typed group hierarchies |
+| Dynamic plugin | `inventories/prod.aws_ec2.yml` | Cloud-authoritative truth; avoid drift |
+| Hybrid | `inventories/prod/{dynamic.aws_ec2.yml, static.yml, group_vars/, host_vars/}` | Dynamic hosts + hand-tagged exceptions |
+
+```text
+inventories/
+  prod/
+    hosts                 # static INI or YAML
+    aws_ec2.yml           # dynamic plugin config (in same dir = merged)
+    group_vars/
+      all.yml             # beats inventory-inline but loses to host_vars
+      web.yml
+    host_vars/
+      web01.yml
+```
+
+Minimal dynamic inventory plugin (AWS EC2):
+
+```yaml
+# inventories/prod/aws_ec2.yml
+plugin: amazon.aws.aws_ec2
+regions:
+  - us-east-1
+keyed_groups:
+  - key: tags.Role
+    prefix: role
+  - key: tags.Env
+    prefix: env
+hostnames:
+  - tag:Name
+  - private-ip-address
+compose:
+  ansible_host: private_ip_address
+```
+
+Rules:
+
+- ❌ Putting `group_vars/` at the repo root *and* inside `inventories/prod/` → two sources collide by precedence, hard to debug.
+- ✅ Keep `group_vars/` / `host_vars/` inside each `inventories/<env>/` directory; never at repo root.
+- ❌ Mixing static `hosts` with a dynamic plugin in *different* directories; Ansible won't merge them.
+- ✅ Put static + dynamic files in the same `inventories/<env>/` dir — Ansible merges them automatically.
+
+## Dynamic Inventory Pitfalls
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Unbounded re-query | Inventory plugin hits cloud API on every `ansible-playbook` run | `cache: true` + `cache_plugin: jsonfile` in plugin config |
+| Cache staleness | Host added to cloud not visible until cache expiry | Short `cache_timeout` or `ansible-inventory --refresh-cache` in CI |
+| `ansible_host` vs `inventory_hostname` divergence | `inventory_hostname` is a tag, but ssh needs IP | Use `compose: { ansible_host: private_ip_address }` |
+| `--limit` against dynamic group | Group empty at play start → play silently runs against 0 hosts | `ansible-inventory --graph --limit=foo` to confirm non-empty |
+| Plugin auth ambient vs explicit | Works locally, fails in CI when IAM role absent | Assume an explicit IAM role in CI job; never rely on developer creds |
+| Plugin version drift | New tag schema causes groupings to disappear | Pin plugin's collection version in `requirements.yml` |
+
+Rules:
+
+- ❌ Rely on `inventory_hostname` as the ssh target → ✅ Set `ansible_host` via `compose:` in the plugin config.
+- ❌ Skip `cache: true` on a plugin that hits a rate-limited API → ✅ Always cache; tune `cache_timeout` per environment.
+- ❌ Trust `--limit foo` when `foo` is a dynamic group → ✅ Run `ansible-inventory --graph --limit=foo` first to confirm the group is non-empty.
+- ❌ Commit cloud credentials alongside inventory config → ✅ Rely on instance IAM role (CI) or `aws configure sso` (local); never inline creds.
+
+## set_fact vs vars
+
+| Goal | Use | Persistence scope | Cacheable? |
+|------|-----|-------------------|------------|
+| One-shot per play | Play/task `vars` | That play only | n/a |
+| Value derived from module output | `register:` | Task run lifetime | n/a |
+| Cross-play persistence in same run | `set_fact:` | Rest of the run | Yes — `cacheable: true` + fact cache |
+| Cross-run persistence | Fact cache (`cacheable: true`) | Until cache expires | Yes, mandatory |
+| Loop item transformation | Task-level `vars:` with `lookup` / filter | That task only | n/a |
+| Computed constant used many times | `set_fact` early in play | Rest of run | Optional |
+
+```yaml
+- name: Fetch version once, reuse across tasks
+  ansible.builtin.command: /opt/app/bin/app --version
+  register: version_cmd
+  changed_when: false
+
+- name: Store as fact for other plays
+  ansible.builtin.set_fact:
+    app_version: "{{ version_cmd.stdout | trim }}"
+    cacheable: true
+```
+
+Rules:
+
+- ❌ `set_fact` in a loop with the same fact name, different item values → ✅ Use `set_fact` outside the loop with a list comprehension: `my_list: "{{ items | map('regex_replace', ...) | list }}"`.
+- ❌ `register:` on a loop and then reading `.stdout` (it's a list of items, each with its own result) → ✅ `register: r` then iterate `r.results[]`.
+- ❌ Assume `set_fact` persists across `ansible-playbook` invocations without fact caching → ✅ Set `cacheable: true` and configure `fact_caching` in `ansible.cfg`.
+- ❌ `set_fact: cacheable: true` with a secret value → ✅ Facts cached to disk/redis; treat as sensitive storage and don't cache secrets.
+- ❌ Use `vars:` for a value computed from a module → ✅ That's what `register` is for; `vars:` is static at compile time.
+
+### LLM Mistake Checklist
+
+- ❌ Declare "`group_vars/all` always wins over `host_vars`" → ✅ `host_vars/<host>` (level 9) beats inventory `group_vars/all` (level 4) for that host.
+- ❌ Place `group_vars/` at the repo root for an inventory-per-env layout → ✅ Nest under each `inventories/<env>/` to prevent cross-env leakage.
+- ❌ Use `vars:` to capture a computed value → ✅ Use `register:` or `set_fact`.
+- ❌ Omit `cache: true` on a dynamic inventory plugin → ✅ Always cache; pair with `ansible-inventory --refresh-cache` in CI.
+- ❌ Trust `--limit` against a dynamic group without checking membership → ✅ `ansible-inventory --graph --limit=foo` before any run.
+- ❌ Call `inventory_hostname` the ssh target on a cloud inventory → ✅ Set `ansible_host` via `compose:` to the private/public IP.
+- ❌ Ship `--extra-vars` as a CI default without scoping → ✅ Use only when explicitly required; extra-vars beats every other precedence level.

--- a/skills/ansible-skill/references/inventory-and-variables.md
+++ b/skills/ansible-skill/references/inventory-and-variables.md
@@ -87,7 +87,7 @@ Rules:
 | Pitfall | Symptom | Fix |
 |---------|---------|-----|
 | Unbounded re-query | Inventory plugin hits cloud API on every `ansible-playbook` run | `cache: true` + `cache_plugin: jsonfile` in plugin config |
-| Cache staleness | Host added to cloud not visible until cache expiry | Short `cache_timeout` or `ansible-inventory --refresh-cache` in CI |
+| Cache staleness | Host added to cloud not visible until cache expiry | Short `cache_timeout` or `ansible-inventory --flush-cache` in CI |
 | `ansible_host` vs `inventory_hostname` divergence | `inventory_hostname` is a tag, but ssh needs IP | Use `compose: { ansible_host: private_ip_address }` |
 | `--limit` against dynamic group | Group empty at play start → play silently runs against 0 hosts | `ansible-inventory --graph --limit=foo` to confirm non-empty |
 | Plugin auth ambient vs explicit | Works locally, fails in CI when IAM role absent | Assume an explicit IAM role in CI job; never rely on developer creds |
@@ -144,7 +144,7 @@ Rules:
 - ❌ Declare "`group_vars/all` always wins over `host_vars`" → ✅ `host_vars/<host>` (level 9) beats inventory `group_vars/all` (level 4) for that host.
 - ❌ Place `group_vars/` at the repo root for an inventory-per-env layout → ✅ Nest under each `inventories/<env>/` to prevent cross-env leakage.
 - ❌ Use `vars:` to capture a computed value → ✅ Use `register:` or `set_fact`.
-- ❌ Omit `cache: true` on a dynamic inventory plugin → ✅ Always cache; pair with `ansible-inventory --refresh-cache` in CI.
+- ❌ Omit `cache: true` on a dynamic inventory plugin → ✅ Always cache; pair with `ansible-inventory --flush-cache` in CI.
 - ❌ Trust `--limit` against a dynamic group without checking membership → ✅ `ansible-inventory --graph --limit=foo` before any run.
 - ❌ Call `inventory_hostname` the ssh target on a cloud inventory → ✅ Set `ansible_host` via `compose:` to the private/public IP.
 - ❌ Ship `--extra-vars` as a CI default without scoping → ✅ Use only when explicitly required; extra-vars beats every other precedence level.

--- a/skills/ansible-skill/references/inventory-and-variables.md
+++ b/skills/ansible-skill/references/inventory-and-variables.md
@@ -8,7 +8,7 @@ Canonical Ansible precedence order (lowest → highest). 22 levels per the offic
 
 | Level | Source | Example path / syntax | Common collision |
 |-------|--------|----------------------|------------------|
-| 1 | Command line values (not `-e`) | `-u myuser`, `-b`, `-K` | Forgetting `--become-user` overrides `become_user:` |
+| 1 | Command line connection/become flags | `-u myuser` → `ansible_user`; `-b`/`-K` → `ansible_become`/prompt | Sets connection/become magic vars only (not arbitrary variables). For variables, use `-e` at level 22 |
 | 2 | Role defaults | `roles/<role>/defaults/main.yml` | Role author's default silently lost the moment anyone sets a group_var |
 | 3 | Inventory file / script group vars (inline) | `[web:vars]` section in `hosts.ini` | Beaten by every file-based group_vars entry |
 | 4 | Inventory `group_vars/all` | `inventories/prod/group_vars/all.yml` | Assumed "global" but overridden by any narrower group |
@@ -18,7 +18,7 @@ Canonical Ansible precedence order (lowest → highest). 22 levels per the offic
 | 8 | Inventory file / script host vars (inline) | `web01 ansible_host=1.2.3.4 myvar=x` | Beaten by every file-based host_vars entry |
 | 9 | Inventory `host_vars/<host>` | `inventories/prod/host_vars/web01.yml` | Always beats group_vars for that host |
 | 10 | Playbook `host_vars/<host>` | Repo-root `host_vars/web01.yml` | Silent override of inventory host_vars |
-| 11 | Host facts / cached `set_fact` (with `cacheable: true`) | `ansible_facts.*`, facts cache | Stale cache returns yesterday's value |
+| 11 | Host facts (auto-gathered) + fact-cached `set_fact` from **prior** runs | `ansible_facts.*`, values cached to disk/redis | Stale cache returns yesterday's value. Note: runtime `set_fact` in **this** run is level 19, not here |
 | 12 | Play `vars` | `vars:` block on a play | Scoped to the play only, forgotten cross-play |
 | 13 | Play `vars_prompt` | Interactive prompts | CI can't answer — task hangs |
 | 14 | Play `vars_files` | `vars_files: [secrets.yml]` | Merge order is list-order, last file wins |
@@ -26,7 +26,7 @@ Canonical Ansible precedence order (lowest → highest). 22 levels per the offic
 | 16 | Block vars | `vars:` on a `block:` | Only visible inside that block |
 | 17 | Task vars | `vars:` on a single task | Highest lexical scope, still beaten by extra-vars |
 | 18 | `include_vars` | `ansible.builtin.include_vars: secrets.yml` | Runs at task time, not play start — timing surprises |
-| 19 | `set_fact` / registered vars | `register: out` / `set_fact: k=v` | Persists across plays in same run (unless `cacheable: false`) |
+| 19 | Runtime `set_fact` / registered vars (this run) | `register: out` / `set_fact: k=v` | Persists across every later play **in this playbook run** regardless of `cacheable`. `cacheable: true` additionally writes the value to the fact cache so it becomes a level-11 fact in future runs |
 | 20 | Role params (include_role) | `include_role: name=foo vars={k: v}` | Inline role call, overrides role defaults + vars |
 | 21 | Include params | `include_tasks: foo.yml vars={k: v}` | Wins over most things except extra-vars |
 | 22 | `--extra-vars` / `-e` | `-e @secrets.yml`, `-e k=v` | **Always wins** — a stray CI flag silently overrides protected config |
@@ -102,14 +102,14 @@ Rules:
 
 ## set_fact vs vars
 
-| Goal | Use | Persistence scope | Cacheable? |
-|------|-----|-------------------|------------|
+| Goal | Use | Persistence scope | `cacheable:` needed? |
+|------|-----|-------------------|---------------------|
 | One-shot per play | Play/task `vars` | That play only | n/a |
 | Value derived from module output | `register:` | Task run lifetime | n/a |
-| Cross-play persistence in same run | `set_fact:` | Rest of the run | Yes — `cacheable: true` + fact cache |
-| Cross-run persistence | Fact cache (`cacheable: true`) | Until cache expires | Yes, mandatory |
+| Cross-play persistence **in same playbook run** | `set_fact:` | Rest of the run | **No** — plain `set_fact` already persists across later plays in the same run |
+| Cross-run persistence (survive `ansible-playbook` exit) | `set_fact:` + `cacheable: true` + a fact-caching plugin | Until cache expires | Yes, mandatory; configure `fact_caching` in `ansible.cfg` |
 | Loop item transformation | Task-level `vars:` with `lookup` / filter | That task only | n/a |
-| Computed constant used many times | `set_fact` early in play | Rest of run | Optional |
+| Computed constant used many times | `set_fact` early in play | Rest of run | No |
 
 ```yaml
 - name: Fetch version once, reuse across tasks

--- a/skills/ansible-skill/references/inventory-and-variables.md
+++ b/skills/ansible-skill/references/inventory-and-variables.md
@@ -117,7 +117,15 @@ Rules:
   register: version_cmd
   changed_when: false
 
-- name: Store as fact for other plays
+# Cross-play in the SAME run: plain set_fact is enough — `cacheable` not needed.
+- name: Store for later plays in this run
+  ansible.builtin.set_fact:
+    app_version: "{{ version_cmd.stdout | trim }}"
+
+# Cross-RUN persistence: add `cacheable: true` AND configure a fact-caching plugin
+# in ansible.cfg (e.g. `fact_caching = jsonfile`); the value becomes a level-11
+# host fact in subsequent ansible-playbook runs.
+- name: Store for future runs (requires fact_caching configured)
   ansible.builtin.set_fact:
     app_version: "{{ version_cmd.stdout | trim }}"
     cacheable: true

--- a/skills/ansible-skill/references/quick-reference.md
+++ b/skills/ansible-skill/references/quick-reference.md
@@ -73,24 +73,24 @@ When a play fails, walk this tree top-down.
 
 | Goal | Preferred module | Minimal example |
 |------|------------------|-----------------|
-| Install package (any distro) | `ansible.builtin.package` | `package: name=nginx state=present` |
-| Start/enable a systemd unit | `ansible.builtin.systemd` | `systemd: name=nginx state=started enabled=true` |
-| Copy a file (with backup) | `ansible.builtin.copy` | `copy: src=nginx.conf dest=/etc/nginx/nginx.conf backup=yes` |
-| Render a template | `ansible.builtin.template` | `template: src=app.conf.j2 dest=/etc/app.conf mode=0640` |
-| Create/write a small file | `ansible.builtin.file` + `ansible.builtin.copy` | `file: path=/opt/app state=directory mode=0755` then `copy: content='...' dest=/opt/app/version` |
-| Install or update Python deps | `ansible.builtin.pip` | `pip: requirements=/opt/app/requirements.txt virtualenv=/opt/app/venv` |
-| Add/remove a cron job | `ansible.builtin.cron` | `cron: name='rotate logs' minute=0 hour=3 job='/usr/bin/logrotate -f'` |
-| Create a local user | `ansible.builtin.user` | `user: name=app state=present shell=/bin/bash` |
-| Open a firewall port (firewalld) | `ansible.posix.firewalld` | `firewalld: port=443/tcp permanent=yes state=enabled` |
-| Open a firewall port (UFW) | `community.general.ufw` | `ufw: rule=allow port=443 proto=tcp` |
-| Mount a filesystem | `ansible.posix.mount` | `mount: path=/data src=/dev/sdb1 fstype=ext4 state=mounted` |
-| Download a file with checksum | `ansible.builtin.get_url` | `get_url: url=https://... dest=/tmp/... checksum=sha256:...` |
-| Call a REST API | `ansible.builtin.uri` | `uri: url=https://api/... method=GET return_content=yes` |
-| Manage a git repo on the target | `ansible.builtin.git` | `git: repo=... dest=/srv/app version=v1.2.3` |
-| Manage a Docker container | `community.docker.docker_container` | `docker_container: name=app image=app:1.2.3 state=started` |
-| Apply a Kubernetes manifest | `kubernetes.core.k8s` | `k8s: state=present definition='{{ lookup("file","deploy.yml") \| from_yaml }}'` |
-| Configure a PostgreSQL user | `community.postgresql.postgresql_user` | `postgresql_user: name=app password='{{ db_password }}' no_log=true` |
-| Create an S3 object | `amazon.aws.s3_object` | `s3_object: bucket=my-bucket object=key src=/tmp/file mode=put` |
+| Install package (any distro) | `ansible.builtin.package` | `ansible.builtin.package: name=nginx state=present` |
+| Start/enable a systemd unit | `ansible.builtin.systemd` | `ansible.builtin.systemd: name=nginx state=started enabled=true` |
+| Copy a file (with backup) | `ansible.builtin.copy` | `ansible.builtin.copy: src=nginx.conf dest=/etc/nginx/nginx.conf backup=yes` |
+| Render a template | `ansible.builtin.template` | `ansible.builtin.template: src=app.conf.j2 dest=/etc/app.conf mode=0640` |
+| Create/write a small file | `ansible.builtin.file` + `ansible.builtin.copy` | `ansible.builtin.file: path=/opt/app state=directory mode=0755` then `ansible.builtin.copy: content='...' dest=/opt/app/version` |
+| Install or update Python deps | `ansible.builtin.pip` | `ansible.builtin.pip: requirements=/opt/app/requirements.txt virtualenv=/opt/app/venv` |
+| Add/remove a cron job | `ansible.builtin.cron` | `ansible.builtin.cron: name='rotate logs' minute=0 hour=3 job='/usr/bin/logrotate -f'` |
+| Create a local user | `ansible.builtin.user` | `ansible.builtin.user: name=app state=present shell=/bin/bash` |
+| Open a firewall port (firewalld) | `ansible.posix.firewalld` | `ansible.posix.firewalld: port=443/tcp permanent=yes state=enabled` |
+| Open a firewall port (UFW) | `community.general.ufw` | `community.general.ufw: rule=allow port=443 proto=tcp` |
+| Mount a filesystem | `ansible.posix.mount` | `ansible.posix.mount: path=/data src=/dev/sdb1 fstype=ext4 state=mounted` |
+| Download a file with checksum | `ansible.builtin.get_url` | `ansible.builtin.get_url: url=https://... dest=/tmp/... checksum=sha256:...` |
+| Call a REST API | `ansible.builtin.uri` | `ansible.builtin.uri: url=https://api/... method=GET return_content=yes` |
+| Manage a git repo on the target | `ansible.builtin.git` | `ansible.builtin.git: repo=... dest=/srv/app version=v1.2.3` |
+| Manage a Docker container | `community.docker.docker_container` | `community.docker.docker_container: name=app image=app:1.2.3 state=started` |
+| Apply a Kubernetes manifest | `kubernetes.core.k8s` | `kubernetes.core.k8s: state=present definition='{{ lookup("file","deploy.yml") \| from_yaml }}'` |
+| Configure a PostgreSQL user (secret-bearing) | `community.postgresql.postgresql_user` | `community.postgresql.postgresql_user: name=app password='{{ db_password }}'` — set `no_log: true` at task level (sibling of the module key, not inside its args) |
+| Create an S3 object | `amazon.aws.s3_object` | `amazon.aws.s3_object: bucket=my-bucket object=key src=/tmp/file mode=put` |
 
 ## Version Matrix
 

--- a/skills/ansible-skill/references/quick-reference.md
+++ b/skills/ansible-skill/references/quick-reference.md
@@ -1,0 +1,119 @@
+# Quick Reference
+
+Cheatsheet and lookup tables for day-to-day Ansible work. Load this when the query is "what's the command for X" or "which module should I use for Y".
+
+## Command Cheatsheet
+
+| Goal | Command | Notes |
+|------|---------|-------|
+| Run a playbook | `ansible-playbook -i inventories/prod playbooks/site.yml` | Implicit `--check` is a common foot-gun — `--check` must be explicit |
+| Lint | `ansible-lint` | Reads `.ansible-lint` from project root |
+| Syntax check only | `ansible-playbook --syntax-check site.yml` | Parses YAML and validates module names; no execution |
+| Dry-run with diffs | `ansible-playbook site.yml --check --diff --limit prod` | Last gate before real apply |
+| Limit to group | `ansible-playbook site.yml --limit web` | `--limit` accepts group names, host patterns, and negations (`--limit '!db'`) |
+| Limit to named list | `ansible-playbook site.yml --limit @hosts.txt` | `@file` loads newline-separated host list |
+| Tag filter | `ansible-playbook site.yml --tags config,tls` | Only tasks with those tags |
+| Skip tags | `ansible-playbook site.yml --skip-tags slow,heavy` | Inverse of `--tags` |
+| Encrypt single value inline | `ansible-vault encrypt_string 'secret' --name 'db_password'` | Use for scalar secrets; leaves rest of file diffable |
+| Encrypt whole file | `ansible-vault encrypt group_vars/prod/secrets.yml` | Use when whole file is sensitive |
+| Edit vaulted file | `ansible-vault edit group_vars/prod/secrets.yml` | Decrypts to tmpfile, encrypts on save |
+| Rekey vault | `ansible-vault rekey --new-vault-id prod@new_file secrets.yml` | Rotate the encryption key |
+| Install collections | `ansible-galaxy collection install -r requirements.yml --collections-path ./collections` | Project-local install path |
+| Verify collection signatures | `ansible-galaxy collection verify mycoll --signature-count-threshold 1` | Against Automation Hub GPG keys |
+| Run via EE | `ansible-navigator run site.yml -i inventories/prod --mode stdout` | `--mode stdout` for CI (no TUI) |
+| Inspect inventory | `ansible-inventory -i inventories/prod --graph --limit web` | See what `--limit` will actually match |
+| List hosts that match | `ansible-playbook site.yml --list-hosts --limit web` | Confirm scope before running |
+| ansible-test sanity | `ansible-test sanity --docker` | Inside a collection repo |
+| ansible-test units | `ansible-test units --docker` | Module/plugin unit tests |
+| Molecule test one scenario | `molecule test -s default` | Inside a role directory |
+| Molecule converge once | `molecule converge -s default` | Skip teardown, useful for iteration |
+| Ad-hoc command | `ansible -i inventories/prod web -m ansible.builtin.ping` | Fire one module across matched hosts |
+| Gather facts once | `ansible -i inventories/prod all -m ansible.builtin.setup -a 'filter=ansible_distribution*'` | Debug helper |
+
+## Troubleshooting Flowchart
+
+When a play fails, walk this tree top-down.
+
+- **Play failed**
+  - **Unreachable host**
+    - → Inspect with `ansible -i <inv> <host> -m ping`
+    - → Check SSH: `ssh -vvv <host>`, confirm key in agent, confirm `ansible_host` IP
+    - → For dynamic inventory: `ansible-inventory --graph --limit=<group>` — is the group populated?
+  - **"command not found" inside a task**
+    - → Wrong `ansible_python_interpreter`; set explicit path in `group_vars/all.yml`
+    - → Missing system dep in the EE — add to `bindep.txt` and rebuild
+  - **Module failure with stack trace**
+    - → Re-run with `-vvv` (mind `no_log`) to see module stdin/stdout
+    - → Check collection version in `requirements.yml`; recent "patch" bumps sometimes regress
+    - → Confirm target has the Python modules the Ansible module needs (e.g. `community.postgresql` needs `psycopg2` on target)
+  - **"Vault decrypt failed"**
+    - → Wrong vault-id for the file's label; `head -1 file.yml` shows the label
+    - → `ANSIBLE_VAULT_PASSWORD_FILE` unset or pointing at the wrong file
+    - → File was encrypted with one key, decrypted with another; `ansible-vault rekey` if mid-rotation
+  - **Idempotency warning / `changed=True` on every run**
+    - → See `references/idempotency-patterns.md#module-idempotency-contracts`
+    - → Most common culprits: `command`/`shell` without `changed_when`, `state: touch`, `state: restarted`, `state: latest`
+  - **Handler didn't fire**
+    - → Typo in `notify:` vs handler name → prefer `listen:` topics
+    - → Play failed mid-run and no `force_handlers: true` on the play
+    - → Handlers fire once per play at end; for mid-play needs use `meta: flush_handlers`
+  - **`--check` passes but real apply fails**
+    - → A task has `check_mode: no` or custom module without `supports_check_mode`
+    - → `ignore_errors: true` is masking a real failure under `--check`
+    - → See `references/idempotency-patterns.md#check-mode-coverage`
+  - **Fact gathering hangs or times out**
+    - → Fleet too large with default `forks: 5`; bump forks or narrow `hosts:`
+    - → `gather_subset: all` on slow-fact hosts; scope to `!all,!min,network`
+  - **Wrong variable value**
+    - → See precedence ladder: `references/inventory-and-variables.md#variable-precedence-ladder`
+    - → `ansible -m ansible.builtin.debug -a "var=<name>" <host>` to see what Ansible actually resolves
+    - → Check for `--extra-vars` stray override in the invocation
+
+## Module Recipe Lookup
+
+| Goal | Preferred module | Minimal example |
+|------|------------------|-----------------|
+| Install package (any distro) | `ansible.builtin.package` | `package: name=nginx state=present` |
+| Start/enable a systemd unit | `ansible.builtin.systemd` | `systemd: name=nginx state=started enabled=true` |
+| Copy a file (with backup) | `ansible.builtin.copy` | `copy: src=nginx.conf dest=/etc/nginx/nginx.conf backup=yes` |
+| Render a template | `ansible.builtin.template` | `template: src=app.conf.j2 dest=/etc/app.conf mode=0640` |
+| Create/write a small file | `ansible.builtin.file` + `ansible.builtin.copy` | `file: path=/opt/app state=directory mode=0755` then `copy: content='...' dest=/opt/app/version` |
+| Install or update Python deps | `ansible.builtin.pip` | `pip: requirements=/opt/app/requirements.txt virtualenv=/opt/app/venv` |
+| Add/remove a cron job | `ansible.builtin.cron` | `cron: name='rotate logs' minute=0 hour=3 job='/usr/bin/logrotate -f'` |
+| Create a local user | `ansible.builtin.user` | `user: name=app state=present shell=/bin/bash` |
+| Open a firewall port (firewalld) | `ansible.posix.firewalld` | `firewalld: port=443/tcp permanent=yes state=enabled` |
+| Open a firewall port (UFW) | `community.general.ufw` | `ufw: rule=allow port=443 proto=tcp` |
+| Mount a filesystem | `ansible.posix.mount` | `mount: path=/data src=/dev/sdb1 fstype=ext4 state=mounted` |
+| Download a file with checksum | `ansible.builtin.get_url` | `get_url: url=https://... dest=/tmp/... checksum=sha256:...` |
+| Call a REST API | `ansible.builtin.uri` | `uri: url=https://api/... method=GET return_content=yes` |
+| Manage a git repo on the target | `ansible.builtin.git` | `git: repo=... dest=/srv/app version=v1.2.3` |
+| Manage a Docker container | `community.docker.docker_container` | `docker_container: name=app image=app:1.2.3 state=started` |
+| Apply a Kubernetes manifest | `kubernetes.core.k8s` | `k8s: state=present definition='{{ lookup("file","deploy.yml") | from_yaml }}'` |
+| Configure a PostgreSQL user | `community.postgresql.postgresql_user` | `postgresql_user: name=app password='{{ db_password }}' no_log=true` |
+| Create an S3 object | `amazon.aws.s3_object` | `s3_object: bucket=my-bucket object=key src=/tmp/file mode=put` |
+
+## Version Matrix
+
+| `ansible-core` | Community `ansible` pkg | Release | EOL | EE image tag (OpenShift / creator-ee) |
+|-----------------|--------------------------|---------|-----|---------------------------------------|
+| 2.14 | 7.x | 2022-11 | 2024-05 (EOL) | `creator-ee:v0.21.0` |
+| 2.15 | 8.x | 2023-05 | 2024-11 (EOL) | `creator-ee:v0.22.0` |
+| 2.16 | 9.x | 2023-11 | 2025-05 | `creator-ee:v24.3.0` |
+| 2.17 | 10.x | 2024-05 | 2025-11 | `creator-ee:v24.7.0` |
+| 2.18 | 11.x | 2024-11 | 2026-05 | `creator-ee:v24.12.0` |
+
+Rules:
+
+- ❌ Pin to an EOL `ansible-core` for production → ✅ Upgrade at least one release before EOL; plan migration per `ansible-core` changelog.
+- ❌ Rely on the community `ansible` bundle for production pinning → ✅ Pin `ansible-core` + individual collections via `requirements.yml`.
+- ❌ Skip EE image upgrades "because collections are pinned" → ✅ EE also ships Python, pip packages, and OS libs; bump the image on each `ansible-core` bump.
+
+### LLM Mistake Checklist
+
+- ❌ Suggest `ansible-playbook --check` as a general safety net without `--diff` → ✅ Always pair: `--check --diff`; `--check` alone only tells you something would change, not what.
+- ❌ Recommend `ansible-galaxy role install` for a collection-format role → ✅ `ansible-galaxy collection install`; the two are different installers.
+- ❌ Use `ansible` ad-hoc for anything beyond one-shot diagnosis → ✅ Codify in a playbook; ad-hoc has no review trail.
+- ❌ Guess the module name from short form → ✅ `ansible-doc -l | grep <keyword>` finds the FQCN.
+- ❌ Trust an EOL `ansible-core` version in production → ✅ Check the support matrix in this file and upgrade before EOL.
+- ❌ Use `--tags` without `--list-tags` to verify coverage → ✅ `ansible-playbook --list-tags site.yml` confirms tags exist before running.
+- ❌ Assume `--limit` matches a group that's dynamically populated → ✅ `ansible-inventory --graph --limit=<pattern>` first.

--- a/skills/ansible-skill/references/quick-reference.md
+++ b/skills/ansible-skill/references/quick-reference.md
@@ -6,7 +6,7 @@ Cheatsheet and lookup tables for day-to-day Ansible work. Load this when the que
 
 | Goal | Command | Notes |
 |------|---------|-------|
-| Run a playbook | `ansible-playbook -i inventories/prod playbooks/site.yml` | Implicit `--check` is a common foot-gun — `--check` must be explicit |
+| Run a playbook | `ansible-playbook -i inventories/prod playbooks/site.yml` | Always mutating unless `--check` is passed explicitly. Don't assume dry-run mode |
 | Lint | `ansible-lint` | Reads `.ansible-lint` from project root |
 | Syntax check only | `ansible-playbook --syntax-check site.yml` | Parses YAML and validates module names; no execution |
 | Dry-run with diffs | `ansible-playbook site.yml --check --diff --limit prod` | Last gate before real apply |

--- a/skills/ansible-skill/references/quick-reference.md
+++ b/skills/ansible-skill/references/quick-reference.md
@@ -88,7 +88,7 @@ When a play fails, walk this tree top-down.
 | Call a REST API | `ansible.builtin.uri` | `uri: url=https://api/... method=GET return_content=yes` |
 | Manage a git repo on the target | `ansible.builtin.git` | `git: repo=... dest=/srv/app version=v1.2.3` |
 | Manage a Docker container | `community.docker.docker_container` | `docker_container: name=app image=app:1.2.3 state=started` |
-| Apply a Kubernetes manifest | `kubernetes.core.k8s` | `k8s: state=present definition='{{ lookup("file","deploy.yml") | from_yaml }}'` |
+| Apply a Kubernetes manifest | `kubernetes.core.k8s` | `k8s: state=present definition='{{ lookup("file","deploy.yml") \| from_yaml }}'` |
 | Configure a PostgreSQL user | `community.postgresql.postgresql_user` | `postgresql_user: name=app password='{{ db_password }}' no_log=true` |
 | Create an S3 object | `amazon.aws.s3_object` | `s3_object: bucket=my-bucket object=key src=/tmp/file mode=put` |
 

--- a/skills/ansible-skill/references/quick-reference.md
+++ b/skills/ansible-skill/references/quick-reference.md
@@ -19,7 +19,7 @@ Cheatsheet and lookup tables for day-to-day Ansible work. Load this when the que
 | Edit vaulted file | `ansible-vault edit group_vars/prod/secrets.yml` | Decrypts to tmpfile, encrypts on save |
 | Rekey vault | `ansible-vault rekey --new-vault-id prod@new_file secrets.yml` | Rotate the encryption key |
 | Install collections | `ansible-galaxy collection install -r requirements.yml --collections-path ./collections` | Project-local install path |
-| Verify collection signatures | `ansible-galaxy collection verify mycoll --signature-count-threshold 1` | Against Automation Hub GPG keys |
+| Verify collection signatures | `ansible-galaxy collection verify mycoll --keyring /etc/pki/ansible/keys.gpg --required-valid-signature-count 1` | Fails install if fewer than 1 valid signature found |
 | Run via EE | `ansible-navigator run site.yml -i inventories/prod --mode stdout` | `--mode stdout` for CI (no TUI) |
 | Inspect inventory | `ansible-inventory -i inventories/prod --graph --limit web` | See what `--limit` will actually match |
 | List hosts that match | `ansible-playbook site.yml --list-hosts --limit web` | Confirm scope before running |

--- a/skills/ansible-skill/references/security-and-vault.md
+++ b/skills/ansible-skill/references/security-and-vault.md
@@ -10,7 +10,7 @@ Detail for the `Secret exposure` routing-table category.
 | Per-environment keys | Vault-id with dev/stage/prod IDs | `--vault-id dev@prompt --vault-id prod@file` | Standard team setup |
 | No vault files on disk | Vault-id + system keyring | `--vault-id prod@keychain.sh` (custom script) | Laptops where keyring is trusted |
 | External KMS-backed | Vault-id + KMS lookup script | Script returns decrypted key from AWS KMS / Vault Transit / GCP KMS | Regulated environments |
-| Pre-decrypted secrets | External secret backend (HashiCorp Vault, AWS SM, 1Password) via lookup | `lookup('community.hashi_vault.vault_read', ...)` | Secrets managed outside Ansible entirely |
+| Pre-decrypted secrets | External secret backend (HashiCorp Vault, AWS SM, 1Password) via lookup | Backend-specific lookup, e.g. Vault KV v2: `lookup('community.hashi_vault.vault_kv2_get', ...)` | Secrets managed outside Ansible entirely |
 
 ```ini
 # ansible.cfg
@@ -72,7 +72,7 @@ Rules:
 
 | Backend | Lookup plugin | Collection | Auth |
 |---------|---------------|------------|------|
-| HashiCorp Vault (KV v2) | `community.hashi_vault.vault_read` | `community.hashi_vault` | `VAULT_ADDR`, `VAULT_TOKEN` / Kubernetes service account / AWS IAM |
+| HashiCorp Vault (KV v2) | `community.hashi_vault.vault_kv2_get` (preferred for KV v2) or `community.hashi_vault.vault_read` (lower-level, returns the raw API envelope) | `community.hashi_vault` | `VAULT_ADDR`, `VAULT_TOKEN` / Kubernetes service account / AWS IAM |
 | AWS Secrets Manager | `amazon.aws.secretsmanager_secret` | `amazon.aws` | IAM role on controller or EE |
 | 1Password | `community.general.onepassword` | `community.general` | `op signin` session token |
 | CyberArk Conjur | `cyberark.conjur.conjur_variable` | `cyberark.conjur` | Conjur host identity + api key |

--- a/skills/ansible-skill/references/security-and-vault.md
+++ b/skills/ansible-skill/references/security-and-vault.md
@@ -77,7 +77,7 @@ Rules:
 | 1Password | `community.general.onepassword` | `community.general` | `op signin` session token |
 | CyberArk Conjur | `cyberark.conjur.conjur_variable` | `cyberark.conjur` | Conjur host identity + api key |
 | Azure Key Vault | `azure.azcollection.azure_keyvault_secret` | `azure.azcollection` | Azure AD service principal |
-| GCP Secret Manager | `google.cloud.secret_manager` | `google.cloud` | Service account JSON / workload identity |
+| GCP Secret Manager | `google.cloud.gcp_secret_manager` | `google.cloud` | Service account JSON / workload identity |
 
 ```yaml
 # HashiCorp Vault (KV v2) — use the dedicated kv2 lookup so the return

--- a/skills/ansible-skill/references/security-and-vault.md
+++ b/skills/ansible-skill/references/security-and-vault.md
@@ -80,10 +80,18 @@ Rules:
 | GCP Secret Manager | `google.cloud.secret_manager` | `google.cloud` | Service account JSON / workload identity |
 
 ```yaml
-# HashiCorp Vault
-db_password: "{{ lookup('community.hashi_vault.vault_read',
-                        'secret/data/prod/db',
-                        auth_method='token') | community.hashi_vault.from_vault }}"
+# HashiCorp Vault (KV v2) — use the dedicated kv2 lookup so the return
+# is already the inner `data` mapping. `vault_read` returns the raw API
+# envelope and would require indexing with `.data.data`.
+db_password: "{{ lookup('community.hashi_vault.vault_kv2_get',
+                        'prod/db',
+                        engine_mount_point='secret',
+                        auth_method='token').secret.password }}"
+
+# Equivalent with the lower-level vault_read lookup:
+# db_password: "{{ (lookup('community.hashi_vault.vault_read',
+#                          'secret/data/prod/db',
+#                          auth_method='token')).data.data.password }}"
 
 # AWS Secrets Manager
 api_key: "{{ lookup('amazon.aws.secretsmanager_secret',

--- a/skills/ansible-skill/references/security-and-vault.md
+++ b/skills/ansible-skill/references/security-and-vault.md
@@ -1,0 +1,134 @@
+# Security & Vault
+
+Detail for the `Secret exposure` routing-table category.
+
+## Vault Key Management
+
+| Scale | Strategy | Tool | When to pick |
+|-------|----------|------|--------------|
+| Single dev, single key | Vault password file | `--vault-password-file ~/.vault_pass` | Solo projects, never for teams |
+| Per-environment keys | Vault-id with dev/stage/prod IDs | `--vault-id dev@prompt --vault-id prod@file` | Standard team setup |
+| No vault files on disk | Vault-id + system keyring | `--vault-id prod@keychain.sh` (custom script) | Laptops where keyring is trusted |
+| External KMS-backed | Vault-id + KMS lookup script | Script returns decrypted key from AWS KMS / Vault Transit / GCP KMS | Regulated environments |
+| Pre-decrypted secrets | External secret backend (HashiCorp Vault, AWS SM, 1Password) via lookup | `lookup('community.hashi_vault.vault_read', ...)` | Secrets managed outside Ansible entirely |
+
+```ini
+# ansible.cfg
+[defaults]
+vault_identity_list = dev@~/.vault-dev, prod@~/.vault-prod-kms.sh
+```
+
+```yaml
+# inventories/prod/group_vars/all.yml
+db_password: !vault |
+  $ANSIBLE_VAULT;1.2;AES256;prod
+  66386439653...
+```
+
+Rules:
+
+- ❌ Commit a vault password file to git → ✅ `.gitignore` the key files and mount them from secrets stores at run time.
+- ❌ One shared vault key across dev/stage/prod → ✅ Separate vault-ids per env; a dev compromise shouldn't touch prod.
+- ❌ `ansible-vault encrypt` the whole file when only one value is secret → ✅ `ansible-vault encrypt_string` to encrypt individual values inline; leaves the rest of the file diffable.
+- ❌ Rotate vault keys by re-encrypting in place → ✅ `ansible-vault rekey --new-vault-id new@file` and update vault-id references in one coordinated commit.
+- ❌ Use `--ask-vault-pass` in CI → ✅ Inject vault password via `ANSIBLE_VAULT_PASSWORD_FILE` pointing at a file written by the runner's secret-fetching step.
+
+## no_log Patterns
+
+| Situation | `no_log: true` needed? | Why |
+|-----------|------------------------|-----|
+| Module arg contains a secret string | Yes | Module invocation logged in default verbosity |
+| `register:` on a task returning a secret | Yes on the register target, and on the debug task | Both the task and any later `debug: var=` print it |
+| Loop over a list of secrets (`loop:`) | Yes | Each iteration logs the `item`; without `no_log`, loop leaks every value |
+| Secret only in `environment:` block | Yes | Env vars logged at task start when `-vv` |
+| Template pulling secrets in | Yes on the template task | Template result visible in diff mode |
+| Informational task reading a public value | No | Don't overuse — `no_log` also hides failure details |
+
+```yaml
+- name: Create DB user
+  community.postgresql.postgresql_user:
+    name: appuser
+    password: "{{ db_password }}"
+  no_log: true
+
+- name: Rotate API tokens
+  ansible.builtin.uri:
+    url: https://api.example.com/tokens/rotate
+    method: POST
+    headers:
+      Authorization: "Bearer {{ api_token }}"
+  register: rotation
+  no_log: true
+```
+
+Rules:
+
+- ❌ Set `no_log: true` on a play-wide level → ✅ Scope to specific tasks; play-level hides every failure.
+- ❌ `loop:` over secrets with `no_log: false` → ✅ Every iteration logs the item; always `no_log: true` for secret loops.
+- ❌ `register:` a secret-bearing task without `no_log: true`, then later `debug: var=result` → ✅ Mark the register target no_log *and* avoid debugging registered values that contain secrets.
+- ❌ `no_log: "{{ debug_mode }}"` to "allow toggling" → ✅ Static `true`; someone will set `debug_mode: true` for a real debug session and leak secrets.
+
+## External Secret Backends
+
+| Backend | Lookup plugin | Collection | Auth |
+|---------|---------------|------------|------|
+| HashiCorp Vault (KV v2) | `community.hashi_vault.vault_read` | `community.hashi_vault` | `VAULT_ADDR`, `VAULT_TOKEN` / Kubernetes service account / AWS IAM |
+| AWS Secrets Manager | `amazon.aws.secretsmanager_secret` | `amazon.aws` | IAM role on controller or EE |
+| 1Password | `community.general.onepassword` | `community.general` | `op signin` session token |
+| CyberArk Conjur | `cyberark.conjur.conjur_variable` | `cyberark.conjur` | Conjur host identity + api key |
+| Azure Key Vault | `azure.azcollection.azure_keyvault_secret` | `azure.azcollection` | Azure AD service principal |
+| GCP Secret Manager | `google.cloud.secret_manager` | `google.cloud` | Service account JSON / workload identity |
+
+```yaml
+# HashiCorp Vault
+db_password: "{{ lookup('community.hashi_vault.vault_read',
+                        'secret/data/prod/db',
+                        auth_method='token') | community.hashi_vault.from_vault }}"
+
+# AWS Secrets Manager
+api_key: "{{ lookup('amazon.aws.secretsmanager_secret',
+                    'prod/api-key',
+                    region='us-east-1') }}"
+
+# 1Password
+ssh_passphrase: "{{ lookup('community.general.onepassword',
+                           'SSH Key prod',
+                           field='passphrase',
+                           vault='Engineering') }}"
+```
+
+Rules:
+
+- ❌ Mix vault-encrypted static values with external secret lookups for the same secret → ✅ Pick one source of truth per secret; document which.
+- ❌ Pass backend creds via plaintext group_vars → ✅ The controller's env / IAM role is the root of trust, not another file.
+- ❌ Cache backend responses with `cacheable: true` → ✅ Secrets shouldn't sit in Ansible fact cache; always fetch fresh.
+- ❌ Use a lookup plugin for a secret inside a loop without `no_log: true` → ✅ Loop iteration still logs the rendered value.
+
+## Secrets in Logs and State
+
+| Leak path | Symptom | Fix |
+|-----------|---------|-----|
+| `-v`/`-vv`/`-vvv` in CI | Secrets in workflow logs | Use `no_log: true`; enforce `-v` max in CI runner env |
+| `ansible-navigator` artifact | Full run stored as JSON, includes module results | Redact secrets via `no_log`; treat navigator artifacts as sensitive |
+| Fact cache with secrets | `jsonfile` / `redis` cache contains decrypted secrets | Never `set_fact cacheable=true` with a secret |
+| `--diff` mode on templates | Rendered secrets visible in diff output | `no_log: true` + diff disabled for that task |
+| Registered vars printed via `debug` | Leaked in play output | Pair `register:` with `no_log: true`, avoid `debug: var=` on secret-bearing results |
+| `callback_whitelist = profile_tasks` | Task names + durations posted; if task name contains secret, leaked | Never put secrets in task names |
+
+Rules:
+
+- ❌ Run `ansible-playbook -vvv` in a CI job that handles Vault → ✅ CI should run at default verbosity; use `-v` only for focused debugging with secrets scrubbed.
+- ❌ Store `ansible-navigator` artifacts in S3 without access controls → ✅ Same access rules as production state; they contain decrypted results.
+- ❌ Redact by post-processing logs → ✅ Redact at source with `no_log`; post-processing always misses cases.
+- ❌ `debug: var=result` on a registered secret fetch → ✅ Mark `no_log: true` on the debug task too, or skip it.
+
+### LLM Mistake Checklist
+
+- ❌ Put vault password files in the repo or in a dotfile that's committed → ✅ `.gitignore` vault password files; inject at runtime.
+- ❌ Use one vault-id for all environments → ✅ Per-env vault-ids (`dev`, `stage`, `prod`).
+- ❌ Omit `no_log: true` on a task passing a secret → ✅ Mandatory; forgetting it leaks at `-v` verbosity.
+- ❌ `no_log: true` at play level → ✅ Task level only; play-level hides every failure.
+- ❌ Cache secret values with `set_fact: cacheable=true` → ✅ Never cache secrets to disk/redis.
+- ❌ `register:` a secret fetch + later `debug: var=result` with no safeguard → ✅ Mark both no_log.
+- ❌ Assume CI masked-secrets handles everything → ✅ Runner masking is a last line; `no_log` is the primary control.
+- ❌ Suggest `ansible-vault encrypt <whole file>` when one value is secret → ✅ `encrypt_string` preserves diffability.

--- a/skills/ansible-skill/references/testing-frameworks.md
+++ b/skills/ansible-skill/references/testing-frameworks.md
@@ -1,0 +1,205 @@
+# Testing Frameworks
+
+Detail for the `Testing Strategy` section in SKILL.md.
+
+## Decision Matrix
+
+| Goal | Tool | Cost | Speed | Scope |
+|------|------|------|-------|-------|
+| Is the YAML valid? | `ansible-playbook --syntax-check site.yml` | Free | <1 s | Playbook/role syntax only |
+| Does the code smell right? | `ansible-lint` | Free | 1–5 s | Static rules (fqcn, no-changed-when, risky-shell-pipe, yaml formatting) |
+| Does a role converge on a fresh host? | Molecule + docker/podman | Free | 30–120 s | Role integration against a container |
+| Does a collection's module/plugin work? | `ansible-test units` | Free | 5–30 s | Unit tests for modules + plugins (collection-only) |
+| Does a collection import cleanly? | `ansible-test sanity` | Free | 10–60 s | Import, schema, ignores, pylint/pep8 style |
+| Does a collection module behave against real infra? | `ansible-test integration` | Med | Minutes | Full module runs against real services |
+| Does the whole stack converge end-to-end? | `--check --diff` against staging inventory | High | Minutes | Real plan/diff without applying |
+
+Rules:
+
+- ❌ Skip `ansible-lint` "because tests pass" → lint catches fqcn misses, `changed_when` omissions, Jinja2 mistakes tests don't exercise.
+- ❌ Use Molecule to test a collection's modules → ✅ Molecule tests roles; `ansible-test units/integration` tests collection internals.
+- ❌ Rely on `--syntax-check` as "testing" → it only parses YAML and validates task module names; no behavior is executed.
+
+## ansible-lint
+
+| Rule category | Key rules | Fails if |
+|---------------|-----------|----------|
+| Structure | `fqcn`, `name[play]`, `name[casing]` | Using `copy:` instead of `ansible.builtin.copy`, missing play/task names |
+| Safety | `no-changed-when`, `risky-shell-pipe`, `no-free-form` | `command:` without `changed_when`, shell with `|` without `pipefail` |
+| Variables | `var-naming`, `jinja` | Role vars missing role-name prefix, malformed Jinja2 expressions |
+| YAML | `yaml[*]` | Indent, trailing spaces, document-start |
+| Secrets | `no-log-password`, `risky-file-permissions` | `password:` arg without `no_log: true`, 0777 chmods |
+
+Minimal `.ansible-lint`:
+
+```yaml
+# .ansible-lint (project root)
+profile: production
+exclude_paths:
+  - .cache/
+  - collections/
+skip_list:
+  - yaml[line-length]        # too noisy; markdownlint handles docs
+warn_list:
+  - experimental             # don't fail on rules still in dev
+```
+
+```yaml
+# Task that lint will flag without `changed_when`
+- name: Restart worker if marker present
+  ansible.builtin.command: /usr/local/bin/worker-restart.sh
+  args:
+    creates: /var/run/worker.restarted
+  changed_when: false        # marker-guard makes this informational after first run
+```
+
+Rules:
+
+- ❌ Add rules to `skip_list` without a comment explaining why → ✅ Document each skip; `yaml[line-length]` is the one common exception, everything else needs justification.
+- ❌ Blanket-ignore with `# noqa` on every task → ✅ `# noqa rule-id` targeted at the specific rule and task only.
+- ❌ Run ansible-lint only in CI → ✅ Local pre-commit hook; CI repeats as safety net.
+- ❌ Use `profile: basic` in production → ✅ `profile: production` catches security and idempotency rules `basic` skips.
+
+## Molecule
+
+| Driver | Use | Tradeoff |
+|--------|-----|----------|
+| `docker` | Most roles; fast | Requires Docker daemon on controller; not a systemd-friendly target without privileged |
+| `podman` | Rootless equivalent of docker | Slightly less ecosystem coverage; systemd works with `--systemd` |
+| `delegated` | Test against an already-running target (VM, bare metal) | No lifecycle management; useful for manual CI integration |
+| `vagrant` | Full-VM integration | Slow; use only when the role requires a real kernel (kernel modules, etc.) |
+
+```yaml
+# molecule/default/molecule.yml
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: rocky9
+    image: rockylinux:9
+    pre_build_image: true
+  - name: ubuntu2204
+    image: ubuntu:22.04
+    pre_build_image: true
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_enabled: profile_tasks
+verifier:
+  name: ansible
+```
+
+```yaml
+# molecule/default/converge.yml
+- name: Converge
+  hosts: all
+  roles:
+    - role: nginx-site
+```
+
+```yaml
+# molecule/default/verify.yml
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Confirm nginx is listening
+      ansible.builtin.wait_for:
+        port: 80
+        timeout: 5
+```
+
+Rules:
+
+- ❌ Skip the idempotence test (`molecule test` runs converge twice by default) → ✅ Keep it; a role that isn't idempotent fails the second converge.
+- ❌ Use `driver: docker` without `pre_build_image: true` for every run → layer rebuild is costly; pre-built images cache the base.
+- ❌ Verify with a shell task instead of a module → `verifier:` should assert module results, not arbitrary shell.
+- ❌ Pile all matrix platforms into one scenario → split into scenarios (`molecule/rhel/`, `molecule/debian/`) when tests diverge.
+
+## ansible-test
+
+| Test type | Command | Validates |
+|-----------|---------|-----------|
+| `sanity` | `ansible-test sanity --docker` | Import, schema compliance, pep8/pylint, ignore-file correctness |
+| `units` | `ansible-test units --docker` | Unit tests for modules (`tests/unit/`) and plugins |
+| `integration` | `ansible-test integration --docker <target>` | End-to-end module runs — may require credentials and real services |
+
+Layout inside a collection:
+
+```text
+my-collection/
+  plugins/
+    modules/
+      foo.py
+  tests/
+    unit/
+      plugins/
+        modules/
+          test_foo.py
+    integration/
+      targets/
+        foo/
+          tasks/main.yml
+          aliases     # names tests that need specific env (e.g. `aws`, `needs/root`)
+    sanity/
+      ignore-2.17.txt  # ignored rules, per ansible-core version
+```
+
+Rules:
+
+- ❌ Confuse Molecule and ansible-test — Molecule is for roles, ansible-test is for collections.
+- ❌ Commit large `ignore-*.txt` files without plan to shrink → ✅ Each ignore is technical debt; add an issue per line.
+- ❌ Skip `ansible-test sanity` on a collection PR → it's cheap and catches schema regressions.
+- ❌ Run integration tests that hit real cloud APIs on every PR → gate behind labels or scheduled jobs; expensive.
+
+## Argument Specs
+
+`meta/argument_specs.yml` validates role inputs at invocation time. Use `profile: production` in ansible-lint to enforce.
+
+```yaml
+# roles/nginx-site/meta/argument_specs.yml
+---
+argument_specs:
+  main:
+    short_description: Configure an nginx vhost
+    options:
+      nginx_site_server_name:
+        type: str
+        required: true
+      nginx_site_port:
+        type: int
+        default: 80
+      nginx_site_ssl:
+        type: bool
+        default: false
+      nginx_site_upstreams:
+        type: list
+        elements: dict
+        options:
+          host:
+            type: str
+            required: true
+          port:
+            type: int
+            required: true
+        required: false
+```
+
+Rules:
+
+- ❌ Declare `type: raw` on everything → defeats the point; use concrete types (`str`, `int`, `list`, `dict`, `bool`).
+- ❌ Omit `required: true` on vars the role will fail on if missing → ✅ Mark required inputs so failure happens at invocation, not deep in a handler.
+- ❌ Use free-form role vars with no spec → ✅ Every reusable role gets `argument_specs.yml`; it's the role's type signature.
+- ❌ Document choices via role README instead of `choices:` → ✅ `choices: [http, https]` validates + documents simultaneously.
+- ❌ Skip entry-point specs for `tasks/setup.yml`-style multi-entry roles → each entry point (`main`, `setup`, `teardown`) gets its own spec block.
+
+### LLM Mistake Checklist
+
+- ❌ Propose Molecule to test a collection → ✅ Molecule tests roles; `ansible-test` tests collections.
+- ❌ Skip `ansible-lint` in favor of `--syntax-check` → ✅ Syntax-check validates grammar; lint catches actual anti-patterns.
+- ❌ Add `# noqa` without a rule id → ✅ Always scope: `# noqa command-instead-of-shell`.
+- ❌ Verify Molecule scenarios with shell commands → ✅ Use module-based assertions in `verify.yml`.
+- ❌ Ship a role without `argument_specs.yml` → ✅ Every reusable role needs one; it's the role's input contract.
+- ❌ Run integration tests unconditionally on every collection PR → ✅ Gate behind labels or scheduled jobs.
+- ❌ Leave `ignore-*.txt` entries in a collection without follow-up issues → each is technical debt.

--- a/skills/ansible-skill/references/testing-frameworks.md
+++ b/skills/ansible-skill/references/testing-frameworks.md
@@ -25,7 +25,7 @@ Rules:
 | Rule category | Key rules | Fails if |
 |---------------|-----------|----------|
 | Structure | `fqcn`, `name[play]`, `name[casing]` | Using `copy:` instead of `ansible.builtin.copy`, missing play/task names |
-| Safety | `no-changed-when`, `risky-shell-pipe`, `no-free-form` | `command:` without `changed_when`, shell with `|` without `pipefail` |
+| Safety | `no-changed-when`, `risky-shell-pipe`, `no-free-form` | `command:` without `changed_when`, shell with `\|` without `pipefail` |
 | Variables | `var-naming`, `jinja` | Role vars missing role-name prefix, malformed Jinja2 expressions |
 | YAML | `yaml[*]` | Indent, trailing spaces, document-start |
 | Secrets | `no-log-password`, `risky-file-permissions` | `password:` arg without `no_log: true`, 0777 chmods |

--- a/skills/ansible-skill/references/testing-frameworks.md
+++ b/skills/ansible-skill/references/testing-frameworks.md
@@ -45,12 +45,24 @@ warn_list:
 ```
 
 ```yaml
-# Task that lint will flag without `changed_when`
-- name: Restart worker if marker present
+# Idempotent one-shot: `creates:` skips the task once the marker exists.
+# Do NOT add `changed_when: false` here — the first run genuinely changes
+# state (creates the marker + performs the restart), and suppressing that
+# hides handler notifications and audit evidence.
+- name: Restart worker once, then skip on subsequent runs
   ansible.builtin.command: /usr/local/bin/worker-restart.sh
   args:
     creates: /var/run/worker.restarted
-  changed_when: false        # marker-guard makes this informational after first run
+```
+
+```yaml
+# Informational status probe (never mutates state).
+# Here `changed_when: false` is correct because the task is read-only.
+- name: Probe worker status
+  ansible.builtin.command: systemctl is-active worker
+  register: worker_status
+  changed_when: false
+  failed_when: false
 ```
 
 Rules:
@@ -86,7 +98,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: profile_tasks
+      callbacks_enabled: profile_tasks    # plural; `callback_whitelist` is the deprecated older name
 verifier:
   name: ansible
 ```

--- a/skills/ansible-skill/references/testing-frameworks.md
+++ b/skills/ansible-skill/references/testing-frameworks.md
@@ -83,17 +83,25 @@ Rules:
 
 ```yaml
 # molecule/default/molecule.yml
+# `pre_build_image: true` tells Molecule the image is already Ansible-ready
+# (Python + sudo present). Vanilla `rockylinux:9` and `ubuntu:22.04` are NOT —
+# the first task fails on fact-gathering. Pick an Ansible-ready image (e.g.
+# geerlingguy/docker-*-ansible) or build your own and pin it by digest.
 dependency:
   name: galaxy
 driver:
   name: docker
 platforms:
   - name: rocky9
-    image: rockylinux:9
+    image: geerlingguy/docker-rockylinux9-ansible:latest
     pre_build_image: true
+    command: ""           # use the image's default; many ansible-ready images need no override
+    privileged: true       # required if the role manages systemd units
   - name: ubuntu2204
-    image: ubuntu:22.04
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
     pre_build_image: true
+    command: ""
+    privileged: true
 provisioner:
   name: ansible
   config_options:
@@ -108,7 +116,7 @@ verifier:
 - name: Converge
   hosts: all
   roles:
-    - role: nginx-site
+    - role: nginx_site
 ```
 
 ```yaml
@@ -170,7 +178,7 @@ Rules:
 `meta/argument_specs.yml` validates role inputs at invocation time. Use `profile: production` in ansible-lint to enforce.
 
 ```yaml
-# roles/nginx-site/meta/argument_specs.yml
+# roles/nginx_site/meta/argument_specs.yml
 ---
 argument_specs:
   main:


### PR DESCRIPTION
Closes #1, closes #2, closes #3, closes #4, closes #5, closes #6, closes #7, closes #8, closes #9, closes #10, closes #11, closes #12, closes #13, closes #14, closes #15, closes #16, closes #17

Expanded scope from Phase 2 to Phase 2+3 to address Codex's review finding that shipping SKILL.md without the reference files it routes to produces a broken skill (P2 at SKILL.md:36).

## What this contains

**Phase 2 — SKILL.md content** (9 commits):

| Commit | Task | Section |
|---|---|---|
| bb5ad1a | 12 | Response Contract (7 elements) |
| 95da9f0 | 13 | Workflow (7 steps) |
| e677964 | 14 | Diagnose routing table (9 categories) |
| d210c6a | 15 | When to Use + Core Principles |
| 461c8a4 | 16 | Idempotency / Blast-Radius / Variable-Precedence quick rules |
| b164236 | 17 | Testing Strategy + CI/CD |
| c42220a | 18 | Security & Vault + Collections + Execution Environments |
| 2b108b9 | 19 | Version Management + Modern Features |
| 2a3e0ae | 20 | Reference file index + License |

**Phase 3 — 8 reference files** (8 commits):

| Commit | Task | File |
|---|---|---|
| 999cb17 | 21 | `references/idempotency-patterns.md` (117 lines) |
| 45379fa | 22 | `references/inventory-and-variables.md` (142 lines) |
| 5709462 | 23 | `references/execution-and-runtime.md` (164 lines) |
| e0630a9 | 24 | `references/security-and-vault.md` (134 lines) |
| ea88b50 | 25 | `references/testing-frameworks.md` (205 lines) |
| 416e097 | 26 | `references/ci-cd-workflows.md` (236 lines) |
| 600472f | 27 | `references/collections-and-supply-chain.md` (182 lines) |
| 8d11a78 | 28a | `references/quick-reference.md` (119 lines) |
| 4588441 | 28b | Link-pass on SKILL.md + `23-level` → `22-level` correction |

Plus 3 fix commits: CI infra (markdownlint config file), markdownlint lint nits (MD040/MD036), and Copilot review nits (ansible-docs wording, grammar, version-floor inconsistency).

## Review findings resolved

- **Codex (P2, SKILL.md:36):** routing table pointed at reference files that didn't exist. Resolved — all 8 files are now in this PR, and the link-pass (commit 4588441) converts all plain-backtick mentions to real markdown links.
- **Copilot (L25, L60, L243, L265):**
  - L25 (9-categories-below forward reference) — resolved when the diagnose table landed in the same PR
  - L60 (ambiguous "ansible-docs") — fixed to "the `ansible-doc` CLI or `docs.ansible.com`"
  - L243 (grammar "a" → "an") — fixed
  - L265 (section header "2.14+" but table floor 2.11+) — fixed to "2.11+"

## Metrics

- **SKILL.md:** 290 lines (target <300, hard limit <350)
- **Reference files:** 8 total, each <250 lines
- **Anchor coverage:** all 17 `#anchor` targets referenced from SKILL.md resolve to real headings in the reference files
- **LLM consumption rules:** decision tables first, ❌/✅ format throughout, <400-token subsections, every reference file ends with `### LLM Mistake Checklist`

## Release impact

Auto-release will cut a **minor bump** on merge (feat: commits → minor) — from current v0.0.3 to **v0.1.0**. First "ready" release with a fully routable skill.

## Test plan

- [x] CI: frontmatter, line count, broken-link, markdownlint, marketplace.json — all checks target this branch
- [ ] After merge: reinstall skill in Claude Code and run Phase 4 smoke-test queries (tracked in issue #18)
- [ ] Verify Response Contract emits all 7 elements on representative Ansible queries