### PR TITLE
[codex] Harden release automation and validation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "ansible-skill",
+  "version": "0.1.1",
+  "description": "Diagnose-first Ansible and ansible-core guidance for Claude Code.",
+  "author": {
+    "name": "sadicabubakari"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "ansible",
+    "ansible-core",
+    "configuration-management",
+    "playbooks",
+    "roles",
+    "collections",
+    "molecule",
+    "vault",
+    "execution-environments",
+    "ci-cd"
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "ansible-skill",
+  "version": "0.1.1",
+  "description": "Diagnose-first Ansible and ansible-core guidance for idempotency, blast-radius controls, runtime safety, and CI/CD review.",
+  "author": {
+    "name": "sadicabubakari"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "ansible",
+    "ansible-core",
+    "configuration-management",
+    "playbooks",
+    "roles",
+    "collections",
+    "molecule",
+    "vault",
+    "execution-environments",
+    "ci-cd"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Ansible Skill",
+    "shortDescription": "Ansible playbook, role, collection, and CI/CD guidance",
+    "longDescription": "Diagnose-first guidance for Ansible and ansible-core work. Reviews or generates playbooks, roles, collections, inventory, Vault usage, execution environments, testing, and CI/CD workflows with explicit idempotency evidence and blast-radius controls.",
+    "developerName": "sadicabubakari",
+    "category": "Development",
+    "capabilities": [
+      "Interactive",
+      "Read"
+    ],
+    "defaultPrompt": [
+      "Review this Ansible playbook for idempotency and blast radius.",
+      "Write a safe Ansible role with Molecule validation.",
+      "Debug this Ansible execution environment or CI failure."
+    ],
+    "brandColor": "#EE0000"
+  }
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,9 +18,7 @@
 
 ## Validation
 
-- [ ] Local frontmatter check passes
-- [ ] Local line-count check passes
-- [ ] Local broken-link check passes
+- [ ] `python3 scripts/validate_skill.py` passes
 - [ ] Reloaded skill in Claude Code and confirmed at least one query routes correctly
 
 ## Notes for reviewer

--- a/.github/scripts/bump-version.py
+++ b/.github/scripts/bump-version.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Compute next semver given current version and commit messages since last tag."""
+"""Compute next semver and release notes from commits since the last tag."""
 import json
 import re
 import subprocess
 import sys
 from pathlib import Path
 
-import yaml
-
 ROOT = Path(__file__).resolve().parent.parent.parent
 MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+CLAUDE_PLUGIN = ROOT / ".claude-plugin" / "plugin.json"
+CODEX_PLUGIN = ROOT / ".codex-plugin" / "plugin.json"
 SKILL = ROOT / "skills" / "ansible-skill" / "SKILL.md"
 CHANGELOG = ROOT / "CHANGELOG.md"
+RELEASE_VERSION = ROOT / ".release-version"
+RELEASE_NOTES = ROOT / ".release-notes.md"
+
+FEAT_RE = re.compile(r"^feat(?:\([^)]+\))?:")
+BREAKING_RE = re.compile(r"^BREAKING[ -]CHANGE:", re.MULTILINE)
 
 
 def current_version() -> tuple[int, int, int]:
@@ -27,22 +32,31 @@ def last_tag() -> str | None:
     return res.stdout.strip() or None if res.returncode == 0 else None
 
 
-def commits_since(tag: str | None) -> list[str]:
+def commits_since(tag: str | None) -> list[dict[str, str]]:
     range_arg = f"{tag}..HEAD" if tag else "HEAD"
     res = subprocess.run(
-        ["git", "log", range_arg, "--format=%s", "--no-merges"],
+        ["git", "log", range_arg, "--format=%H%x1f%s%x1f%B%x1e", "--no-merges"],
         capture_output=True, text=True, check=True,
     )
-    return [l for l in res.stdout.splitlines() if l.strip()]
+    commits: list[dict[str, str]] = []
+    for record in res.stdout.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        sha, subject, body = record.split("\x1f", 2)
+        commits.append({"sha": sha, "subject": subject.strip(), "body": body.strip()})
+    return commits
 
 
-def classify(commits: list[str]) -> str:
+def classify(commits: list[dict[str, str]]) -> str:
     bump = "patch"
-    for msg in commits:
-        if "BREAKING CHANGE" in msg or re.match(r"^[a-z]+!:", msg):
+    for commit in commits:
+        subject = commit["subject"]
+        message = commit["body"]
+        if BREAKING_RE.search(message) or re.match(r"^[a-z]+(?:\([^)]+\))?!:", subject):
             return "major"
-        if msg.startswith("feat:") or msg.startswith("feat("):
-            bump = "minor" if bump != "major" else bump
+        if FEAT_RE.match(subject):
+            bump = "minor"
     return bump
 
 
@@ -61,15 +75,30 @@ def sync_versions(new: str) -> None:
     mp["plugins"][0]["version"] = new
     MARKETPLACE.write_text(json.dumps(mp, indent=2) + "\n")
 
+    for path in (CLAUDE_PLUGIN, CODEX_PLUGIN):
+        if path.exists():
+            data = json.loads(path.read_text())
+            data["version"] = new
+            path.write_text(json.dumps(data, indent=2) + "\n")
+
     content = SKILL.read_text()
-    parts = content.split("---", 2)
-    fm = yaml.safe_load(parts[1])
-    fm["metadata"]["version"] = new
-    new_fm = yaml.safe_dump(fm, sort_keys=False, default_flow_style=False)
-    SKILL.write_text(f"---\n{new_fm}---{parts[2]}")
+    updated = re.sub(r"^  version: .*$", f"  version: {new}", content, count=1, flags=re.M)
+    if updated == content:
+        raise RuntimeError("Could not find SKILL.md metadata.version to update")
+    SKILL.write_text(updated)
+
+
+def write_release_notes(new: str, commits: list[dict[str, str]]) -> None:
+    subjects = [commit["subject"] for commit in commits]
+    if not subjects:
+        subjects = ["Release maintenance updates."]
+
+    lines = [f"## v{new}", "", "Changes:"]
+    lines.extend(f"- {subject}" for subject in subjects)
+    RELEASE_NOTES.write_text("\n".join(lines) + "\n")
 
     existing = CHANGELOG.read_text()
-    entry = f"\n## v{new}\n\nSee commit log for details.\n"
+    entry = "\n".join(["", f"## v{new}", "", *[f"- {subject}" for subject in subjects], ""])
     CHANGELOG.write_text(existing.rstrip() + "\n" + entry)
 
 
@@ -85,7 +114,8 @@ def main() -> int:
     new_str = f"{new[0]}.{new[1]}.{new[2]}"
     print(f"Current: {'.'.join(str(x) for x in cur)} | Bump: {bump} | Next: {new_str}")
     sync_versions(new_str)
-    Path(".release-version").write_text(new_str)
+    write_release_notes(new_str, commits)
+    RELEASE_VERSION.write_text(new_str)
     return 0
 
 

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dependencies
+      - name: Show Python version
         if: steps.skip.outputs.skip != 'true'
-        run: pip install pyyaml
+        run: python3 --version
 
       - name: Configure git
         if: steps.skip.outputs.skip != 'true'
@@ -48,19 +48,33 @@ jobs:
         run: python3 .github/scripts/bump-version.py
 
       - name: Commit and tag
+        id: commit_tag
         if: steps.skip.outputs.skip != 'true'
         run: |
           VERSION=$(cat .release-version 2>/dev/null || true)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if [ -z "$VERSION" ]; then
             echo "No version produced; nothing to release."
+            echo "released=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          rm .release-version
-          git add .claude-plugin/marketplace.json skills/ansible-skill/SKILL.md CHANGELOG.md
+          git add .claude-plugin/marketplace.json .claude-plugin/plugin.json .codex-plugin/plugin.json skills/ansible-skill/SKILL.md CHANGELOG.md
           if git diff --cached --quiet; then
             echo "No changes to commit."
+            echo "released=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore(release): v$VERSION [skip ci]"
           git tag "v$VERSION"
           git push origin master --tags
+          echo "released=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.commit_tag.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.commit_tag.outputs.version }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "v${{ steps.commit_tag.outputs.version }}" \
+            --notes-file .release-notes.md

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,82 +2,29 @@ name: Validate skill content
 
 on:
   pull_request:
-    paths:
-      - 'skills/ansible-skill/SKILL.md'
-      - 'skills/ansible-skill/references/**/*.md'
-      - '.claude-plugin/**'
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read
 
 jobs:
-  frontmatter:
-    name: Validate YAML frontmatter
+  package:
+    name: Validate skill package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install pyyaml
-        run: pip install pyyaml
-      - name: Check frontmatter
+      - name: Validate JSON manifests
         run: |
-          python3 <<'PY'
-          import yaml, sys
-          content = open('skills/ansible-skill/SKILL.md').read()
-          parts = content.split('---', 2)
-          if len(parts) < 3:
-              sys.exit("SKILL.md missing YAML frontmatter delimiters")
-          fm = yaml.safe_load(parts[1])
-          required = {'name', 'description', 'license', 'metadata'}
-          missing = required - set(fm.keys())
-          if missing:
-              sys.exit(f"Missing fields: {missing}")
-          if not fm['description'].startswith('Use when'):
-              sys.exit("description must start with 'Use when'")
-          if len(fm['description']) >= 1024:
-              sys.exit(f"description too long: {len(fm['description'])}")
-          if 'version' not in fm.get('metadata', {}):
-              sys.exit("metadata.version missing")
-          print("Frontmatter OK")
-          PY
-
-  line-count:
-    name: Check SKILL.md line count
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Count lines
-        run: |
-          LINES=$(wc -l < skills/ansible-skill/SKILL.md)
-          echo "SKILL.md line count: $LINES"
-          if [ "$LINES" -gt 350 ]; then
-            echo "::error::SKILL.md exceeds 350-line hard limit ($LINES lines)"
-            exit 1
-          fi
-          if [ "$LINES" -gt 300 ]; then
-            echo "::warning::SKILL.md exceeds 300-line target ($LINES lines)"
-          fi
-
-  broken-links:
-    name: Check for broken internal links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Scan for broken references/ links
-        shell: bash
-        run: |
-          cd skills/ansible-skill
-          BROKEN=0
-          LINKS=$(grep -rhoE '\(references/[^)#]+\.md' SKILL.md references/*.md 2>/dev/null | sed 's/^(//' | sort -u || true)
-          for link in $LINKS; do
-            if [ ! -f "$link" ]; then
-              echo "::error::Broken link target: $link"
-              BROKEN=1
-            fi
-          done
-          exit $BROKEN
+          python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
+          python3 -m json.tool .claude-plugin/plugin.json >/dev/null
+          python3 -m json.tool .codex-plugin/plugin.json >/dev/null
+      - name: Validate skill package
+        run: python3 scripts/validate_skill.py
 
   markdown-lint:
     name: markdownlint
@@ -90,28 +37,3 @@ jobs:
           globs: |
             skills/ansible-skill/SKILL.md
             skills/ansible-skill/references/**/*.md
-
-  marketplace-json:
-    name: Validate marketplace.json
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install pyyaml
-        run: pip install pyyaml
-      - name: Parse JSON and check versions sync
-        run: |
-          python3 <<'PY'
-          import json, yaml, sys
-          mp = json.load(open('.claude-plugin/marketplace.json'))
-          skill = open('skills/ansible-skill/SKILL.md').read()
-          fm = yaml.safe_load(skill.split('---', 2)[1])
-          root_v = mp['version']
-          plugin_v = mp['plugins'][0]['version']
-          skill_v = fm['metadata']['version']
-          if not (root_v == plugin_v == skill_v):
-              sys.exit(f"version mismatch: root={root_v} plugin={plugin_v} skill={skill_v}")
-          print(f"All three version slots match: {root_v}")
-          PY

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .DS_Store
 node_modules/
+__pycache__/
 *.log
 .idea/
 .vscode/
 .env
 .env.local
+.release-version
+.release-notes.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,10 @@ A **Claude Code skill** — executable documentation that Claude loads to provid
 
 ```
 ansible-skill/
+├── .codex-plugin/plugin.json        # Codex plugin metadata
 ├── .claude-plugin/marketplace.json  # Plugin metadata (version synced automatically)
+├── .claude-plugin/plugin.json       # Claude plugin metadata
+├── scripts/validate_skill.py        # Local/CI package validation
 ├── skills/
 │   └── ansible-skill/               # Skill autodiscovered by Claude Code plugin system
 │       ├── SKILL.md                 # Core skill file (<300 lines)
@@ -38,30 +41,10 @@ ansible-skill/
 
 ### Validation
 
-CI runs automatically on PRs touching `SKILL.md`, `references/**/*.md`, or `.claude-plugin/**`. To check locally:
+CI runs automatically on PRs and pushes to `master`. To check locally:
 
 ```bash
-# Check SKILL.md line count (target: <300 lines)
-wc -l skills/ansible-skill/SKILL.md
-
-# Validate YAML frontmatter (stdlib regex; no pyyaml required)
-python3 -c "
-import re
-content = open('skills/ansible-skill/SKILL.md').read()
-parts = content.split('---', 2)
-fm = parts[1]
-assert re.search(r'^name:\s+ansible-skill\s*$', fm, re.M), 'missing name'
-assert re.search(r'^description:\s+Use when', fm, re.M), 'description must start with Use when'
-assert re.search(r'^license:\s+Apache-2\.0\s*$', fm, re.M), 'missing license'
-assert re.search(r'^\s+version:', fm, re.M), 'missing metadata.version'
-print('Frontmatter OK')
-"
-
-# Check for broken internal links
-cd skills/ansible-skill
-grep -rhoE '\(references/[^)#]+\.md' SKILL.md references/*.md 2>/dev/null | \
-  sed 's/^(//' | sort -u | \
-  while read -r link; do [ ! -f "$link" ] && echo "Broken: $link"; done
+python3 scripts/validate_skill.py
 ```
 
 ### Testing Changes
@@ -78,17 +61,20 @@ Releases are **fully automated** from conventional commits on `master`:
 
 | Commit prefix | Version bump |
 |---------------|-------------|
-| `feat!:` or `BREAKING CHANGE:` | Major |
-| `feat:` | Minor |
+| `feat!:` / `feat(scope)!:` / `BREAKING CHANGE:` footer | Major |
+| `feat:` / `feat(scope):` | Minor |
 | `fix:` | Patch |
 | Other | Patch (default) |
 
 The release workflow automatically:
 - Bumps the version in `CHANGELOG.md`
-- Syncs versions across **three places** (must stay in sync):
+- Syncs versions across **five places** (must stay in sync):
   1. `.claude-plugin/marketplace.json` → `version` (root)
   2. `.claude-plugin/marketplace.json` → `plugins[0].version`
   3. `skills/ansible-skill/SKILL.md` YAML frontmatter → `metadata.version`
+  4. `.claude-plugin/plugin.json` → `version`
+  5. `.codex-plugin/plugin.json` → `version`
+- Creates a GitHub Release for the new tag using generated notes from commits since the previous tag
 
 **Never manually edit version numbers** — the CI handles this.
 
@@ -113,7 +99,7 @@ metadata:
 
 ### Progressive Disclosure Pattern
 
-SKILL.md is the entry point. Reference files load on demand. Cross-links use relative paths: `[Testing Guide](references/testing-frameworks.md)`.
+SKILL.md is the entry point. Reference files load on demand. Cross-links inside the skill use paths relative to the skill directory, such as `references/testing-frameworks.md`.
 
 When adding content, ask: **decision framework or key pattern → SKILL.md; detailed example or template → reference file.**
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,22 @@ Every Ansible response from Claude emits a two-axis Response Contract:
 6. **Validation plan** — exact `ansible-lint`, `--syntax-check`, `--check --diff`, Molecule, ansible-test commands
 7. **Rollback notes** — how to undo any destructive play
 
-## Install (Claude Code plugin marketplace)
+## Install
+
+### Codex
+
+```bash
+codex plugin marketplace add olandodeflexy/ansible-skill
+```
+
+For local development from a checkout:
+
+```bash
+mkdir -p ~/.codex/skills
+ln -s "$(pwd)/skills/ansible-skill" ~/.codex/skills/ansible-skill
+```
+
+### Claude Code
 
 ```bash
 # From Claude Code
@@ -40,7 +55,7 @@ Claude loads only the reference files relevant to your query.
 | Idempotency drift | `changed=True` loops, `command`/`shell` without guards, handler misfires |
 | Blast radius | `serial`, `max_fail_percentage`, `--limit` safety, fact-gathering scope |
 | Secret exposure | Vault, `no_log`, external secret backends, log leakage |
-| Variable precedence bugs | 23-level chain collisions |
+| Variable precedence bugs | 22-level chain collisions |
 | Inventory correctness | Static/dynamic drift, group membership |
 | Handler/ordering | `meta: flush_handlers`, `listen` topics |
 | Check-mode blind spots | `--check` compatibility, `ignore_errors` pitfalls |

--- a/scripts/validate_skill.py
+++ b/scripts/validate_skill.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Validate the Ansible skill package without third-party dependencies."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = ROOT / "skills" / "ansible-skill"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REQUIRED_REFS = {
+    "ci-cd-workflows.md",
+    "collections-and-supply-chain.md",
+    "execution-and-runtime.md",
+    "idempotency-patterns.md",
+    "inventory-and-variables.md",
+    "quick-reference.md",
+    "security-and-vault.md",
+    "testing-frameworks.md",
+}
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def fail(message: str) -> None:
+    print(f"[ERROR] {message}")
+    sys.exit(1)
+
+
+def parse_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def parse_simple_yaml_mapping(content: str, source: str) -> dict[str, Any]:
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any]]] = [(-1, root)]
+
+    for line_number, raw_line in enumerate(content.splitlines(), start=1):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if "\t" in raw_line:
+            fail(f"{source}:{line_number} contains a tab; use spaces for YAML")
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent % 2 != 0:
+            fail(f"{source}:{line_number} uses odd indentation")
+
+        line = raw_line.strip()
+        if ":" not in line or line.startswith("- "):
+            fail(f"{source}:{line_number} must be a key/value mapping")
+
+        key, value = line.split(":", 1)
+        key = key.strip()
+        if not key:
+            fail(f"{source}:{line_number} has an empty YAML key")
+
+        while indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+        parent_indent = stack[-1][0]
+        expected_indent = 0 if parent_indent == -1 else parent_indent + 2
+        if indent != expected_indent:
+            fail(f"{source}:{line_number} has indent {indent}; expected {expected_indent}")
+
+        if not value.strip():
+            child: dict[str, Any] = {}
+            parent[key] = child
+            stack.append((indent, child))
+        else:
+            parent[key] = parse_scalar(value)
+
+    return root
+
+
+def parse_frontmatter(content: str) -> dict[str, Any]:
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        fail("SKILL.md missing YAML frontmatter")
+    return parse_simple_yaml_mapping(match.group(1), "SKILL.md frontmatter")
+
+
+def require_path(data: dict[str, Any], keys: tuple[str, ...], label: str) -> str:
+    value: Any = data
+    for key in keys:
+        if not isinstance(value, dict) or key not in value:
+            fail(f"{label} missing {'.'.join(keys)}")
+        value = value[key]
+    if not isinstance(value, str) or not value:
+        fail(f"{label} field {'.'.join(keys)} must be a non-empty string")
+    return value
+
+
+def slugify(heading: str) -> str:
+    slug = heading.strip().lower().replace("&", "")
+    slug = re.sub(r"[`*_{}\[\]()<>=!?:,.\"'\\]", "", slug)
+    return re.sub(r"\s+", "-", slug)
+
+
+def heading_slugs(path: Path) -> set[str]:
+    slugs: set[str] = set()
+    for match in re.finditer(r"^(#{1,6})\s+(.+?)\s*#*$", path.read_text(), re.M):
+        slugs.add(slugify(match.group(2)))
+    return slugs
+
+
+def check_exists() -> None:
+    required = [
+        SKILL_MD,
+        ROOT / ".claude-plugin" / "marketplace.json",
+        ROOT / ".claude-plugin" / "plugin.json",
+        ROOT / ".codex-plugin" / "plugin.json",
+        ROOT / ".gitignore",
+    ]
+    for path in required:
+        if not path.exists():
+            fail(f"Missing required file: {path.relative_to(ROOT)}")
+
+    refs_dir = SKILL_DIR / "references"
+    missing_refs = sorted(REQUIRED_REFS - {path.name for path in refs_dir.glob("*.md")})
+    if missing_refs:
+        fail(f"Missing references: {', '.join(missing_refs)}")
+
+
+def check_skill_md() -> dict[str, Any]:
+    content = SKILL_MD.read_text()
+    lines = content.splitlines()
+    if len(lines) > 300:
+        fail(f"SKILL.md has {len(lines)} lines; target is <= 300")
+
+    frontmatter = parse_frontmatter(content)
+    if frontmatter.get("name") != "ansible-skill":
+        fail("SKILL.md frontmatter name must be ansible-skill")
+    description = frontmatter.get("description")
+    if not isinstance(description, str) or not description.startswith("Use when"):
+        fail("SKILL.md description must start with 'Use when'")
+    if len(description) >= 1024:
+        fail(f"SKILL.md description is too long: {len(description)}")
+    if frontmatter.get("license") != "Apache-2.0":
+        fail("SKILL.md license must be Apache-2.0")
+    if "Response Contract" not in content:
+        fail("SKILL.md missing Response Contract")
+    return frontmatter
+
+
+def check_links() -> None:
+    markdown_files = sorted(path for path in ROOT.rglob("*.md") if ".git" not in path.parts)
+    slug_cache: dict[Path, set[str]] = {}
+
+    for path in markdown_files:
+        for match in MARKDOWN_LINK_RE.finditer(path.read_text()):
+            raw_target = match.group(1).strip()
+            if raw_target.startswith("<") and raw_target.endswith(">"):
+                raw_target = raw_target[1:-1]
+            if raw_target.startswith("#"):
+                continue
+            if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", raw_target) or raw_target.startswith("//"):
+                continue
+
+            target_name, _, anchor = raw_target.partition("#")
+            target_name = target_name.split("?", 1)[0]
+            if not target_name.lower().endswith(".md"):
+                continue
+
+            target = (path.parent / target_name).resolve()
+            try:
+                target.relative_to(ROOT.resolve())
+            except ValueError:
+                fail(f"Markdown link in {path.relative_to(ROOT)} points outside repo: {raw_target}")
+            if not target.exists():
+                fail(f"Broken Markdown link in {path.relative_to(ROOT)}: {raw_target}")
+            if anchor:
+                slug_cache.setdefault(target, heading_slugs(target))
+                if anchor not in slug_cache[target]:
+                    fail(f"Broken Markdown anchor in {path.relative_to(ROOT)}: {raw_target}")
+
+
+def load_json(rel: str) -> dict[str, Any]:
+    path = ROOT / rel
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"Invalid JSON in {rel}: {exc}")
+    if not isinstance(data, dict):
+        fail(f"{rel} must contain a JSON object")
+    return data
+
+
+def check_versions(frontmatter: dict[str, Any]) -> None:
+    marketplace = load_json(".claude-plugin/marketplace.json")
+    plugins = marketplace.get("plugins")
+    if not isinstance(plugins, list) or not plugins or not isinstance(plugins[0], dict):
+        fail(".claude-plugin/marketplace.json must contain plugins[0]")
+
+    versions = {
+        "SKILL.md metadata.version": require_path(frontmatter, ("metadata", "version"), "SKILL.md"),
+        ".claude-plugin/marketplace.json version": require_path(
+            marketplace, ("version",), ".claude-plugin/marketplace.json"
+        ),
+        ".claude-plugin/marketplace.json plugins[0].version": require_path(
+            plugins[0], ("version",), ".claude-plugin/marketplace.json plugins[0]"
+        ),
+        ".claude-plugin/plugin.json version": require_path(
+            load_json(".claude-plugin/plugin.json"), ("version",), ".claude-plugin/plugin.json"
+        ),
+        ".codex-plugin/plugin.json version": require_path(
+            load_json(".codex-plugin/plugin.json"), ("version",), ".codex-plugin/plugin.json"
+        ),
+    }
+
+    if len(set(versions.values())) != 1:
+        details = ", ".join(f"{name}={version}" for name, version in versions.items())
+        fail(f"Version mismatch: {details}")
+
+
+def check_gitignore() -> None:
+    forbidden_patterns = {
+        "*.json",
+        "*.md",
+        "*.yaml",
+        "*.yml",
+        ".claude-plugin/",
+        ".codex-plugin/",
+        ".github/",
+        "scripts/",
+        "skills/",
+    }
+    patterns = {
+        line.strip()
+        for line in (ROOT / ".gitignore").read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    blocked = sorted(forbidden_patterns & patterns)
+    if blocked:
+        fail(f".gitignore excludes package source files: {', '.join(blocked)}")
+
+
+def main() -> int:
+    check_exists()
+    frontmatter = check_skill_md()
+    check_links()
+    check_versions(frontmatter)
+    check_gitignore()
+    print("[OK] Ansible skill validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ansible-skill/SKILL.md
+++ b/skills/ansible-skill/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: ansible-skill
-description: "Use when writing, reviewing, or debugging Ansible playbooks, roles,\
-  \ collections, inventory, Vault, Molecule, execution environments, or CI \u2014\
-  \ diagnoses failure mode (idempotency drift, blast radius, secret exposure, variable\
-  \ precedence, inventory correctness, handler ordering, check-mode blind spots, collection\
-  \ supply chain, execution environment) with two-axis risk framing."
+description: "Use when writing, reviewing, or debugging Ansible playbooks, roles, collections, inventory, Vault, Molecule, execution environments, or CI; diagnoses failure modes with explicit idempotency, blast-radius, secret exposure, variable precedence, inventory correctness, handler ordering, check-mode, supply-chain, and runtime risk framing."
 license: Apache-2.0
 metadata:
   author: sadicabubakari
@@ -19,7 +15,7 @@ Diagnose-first guidance for Ansible and ansible-core. Core file is a workflow; d
 
 Every Ansible response must include:
 
-1. **Assumptions & version floor** — `ansible-core` version, collections in `requirements.yml` with versions, Python interpreter target (`ansible_python_interpreter`), connection plugin (ssh/winrm/local), control node vs execution-environment runtime. State explicitly when the user did not provide them. **When no version is given, assume the lowest currently-supported `ansible-core` minor from the [Version Matrix](references/quick-reference.md#version-matrix)** (e.g. `2.18+` rather than `2.14+`/`2.16+`); recommending an EOL floor produces guidance that's already past its support window.
+1. **Assumptions & version floor** — `ansible-core` version, collections in `requirements.yml` with versions, Python interpreter target (`ansible_python_interpreter`), connection plugin (ssh/winrm/local), control node vs execution-environment runtime. State explicitly when the user did not provide them. **When no version is given, assume the lowest supported `ansible-core` minor with EOL runway from the [Version Matrix](references/quick-reference.md#version-matrix)** (currently `2.19+`; `2.18` is security-only and near EOL). Recommending an EOL floor produces guidance that's already past its support window.
 2. **Idempotency evidence** — for each task introduced or modified: why `changed=True` only when the world actually changed. Name the module's idempotency contract (native module idempotent; `command`/`shell` requires `creates`/`removes`/`changed_when`).
 3. **Blast-radius controls** — inventory target (hosts/groups/limit), `serial` / `max_fail_percentage` / `any_errors_fatal` decision, `--check` + `--diff` coverage, whether this is safe to run against prod as-is.
 4. **Risk category addressed** — one or more of the 9 diagnose-table categories below.
@@ -186,7 +182,7 @@ Pipeline stages: **lint → syntax-check → Molecule (or ansible-test) → stag
 
 **Rules:**
 
-- Pin `ansible-core` to a currently supported minor in CI (e.g. `ansible-core>=2.18,<2.19`); cross-check the [Version Matrix](references/quick-reference.md#version-matrix) before each release cycle and bump off any minor that is past EOL.
+- Pin `ansible-core` to a currently supported minor in CI (e.g. `ansible-core>=2.20,<2.21`); cross-check the [Version Matrix](references/quick-reference.md#version-matrix) before each release cycle and bump off any minor that is past EOL or inside the final security-only window.
 - Pin collections in `requirements.yml` with exact versions for prod branches.
 - Inject vault password via OIDC or masked secret — never a file in the repo.
 - Treat the reviewed `--check --diff` output as an approval artifact, not a replayable plan. The apply job must re-evaluate current state — optionally re-run `--check --diff` against live infrastructure and compare to the approved artifact before executing.
@@ -266,7 +262,7 @@ See [Execution & Runtime](references/execution-and-runtime.md) for EE build patt
 
 | Component | Strategy | Example |
 |-----------|----------|---------|
-| `ansible-core` runtime | Pin minor for prod; pick a non-EOL minor from the [Version Matrix](references/quick-reference.md#version-matrix) | `ansible-core>=2.18,<2.19` (re-evaluate at each release cycle) |
+| `ansible-core` runtime | Pin minor for prod; pick a non-EOL minor from the [Version Matrix](references/quick-reference.md#version-matrix) | `ansible-core>=2.20,<2.21` (re-evaluate at each release cycle) |
 | Community `ansible` package | Pin exact or avoid in prod | Prefer pinning `ansible-core` + collections separately |
 | Collections (prod) | Exact version in `requirements.yml` | `version: "5.1.2"` |
 | Collections (dev) | Allow minor | `version: ">=5.1.0,<6.0.0"` |
@@ -299,9 +295,3 @@ Progressive disclosure — essentials here, depth on demand.
 - [CI/CD Workflows](references/ci-cd-workflows.md) — GitHub Actions, GitLab CI, blast-radius gates, secret handling in CI
 - [Collections & Supply Chain](references/collections-and-supply-chain.md) — `requirements.yml`, fqcn, signature verification, private hubs
 - [Quick Reference](references/quick-reference.md) — command cheatsheet, troubleshooting flowchart, module recipes, version matrix
-
-## License
-
-Apache-2.0. See LICENSE.
-
-Copyright © 2026 sadicabubakari.

--- a/skills/ansible-skill/references/ci-cd-workflows.md
+++ b/skills/ansible-skill/references/ci-cd-workflows.md
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ansible-core==2.18.0 ansible-lint==24.7.0 yamllint==1.35.1
+      - run: pip install 'ansible-core>=2.20,<2.21' ansible-lint==24.7.0 yamllint==1.35.1
       - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
       - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
       - run: ansible-lint
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ansible-core==2.18.0 molecule[docker]==24.7.0 ansible-lint==24.7.0
+      - run: pip install 'ansible-core>=2.20,<2.21' molecule[docker]==24.7.0 ansible-lint==24.7.0
       - run: molecule test -s ${{ matrix.scenario }}
         working-directory: roles/${{ matrix.role }}
 
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ansible-core==2.18.0
+      - run: pip install 'ansible-core>=2.20,<2.21'
       - run: ansible-galaxy collection install -r requirements.yml --collections-path ./collections
       - run: echo "ANSIBLE_COLLECTIONS_PATH=./collections" >> $GITHUB_ENV
       - name: Run --check --diff against staging
@@ -122,10 +122,8 @@ stages:
   - apply
 
 default:
-  # In production, pin by digest, not tag, for reproducibility/supply-chain safety:
-  #   image: quay.io/ansible/creator-ee@sha256:<approved-digest>
-  # The tag form below is only suitable for early-iteration / dev pipelines.
-  image: quay.io/ansible/creator-ee:v24.12.0
+  # Pin by digest for reproducibility/supply-chain safety.
+  image: quay.io/ansible/creator-ee@sha256:<approved-digest>
   cache:
     key: "$CI_COMMIT_REF_SLUG-venv"
     paths:

--- a/skills/ansible-skill/references/collections-and-supply-chain.md
+++ b/skills/ansible-skill/references/collections-and-supply-chain.md
@@ -70,7 +70,7 @@ Fully-qualified collection names prevent clashes when two collections ship modul
 |--------------|---------|
 | `copy:` | `ansible.builtin.copy:` |
 | `template:` | `ansible.builtin.template:` |
-| `service:` | `ansible.builtin.service:` (or `ansible.builtin.systemd:` for systemd-specific) |
+| `service:` | `ansible.builtin.service:` (or `ansible.builtin.systemd_service:` for systemd-specific) |
 | `ec2_instance:` | `amazon.aws.ec2_instance:` |
 | `postgresql_user:` | `community.postgresql.postgresql_user:` |
 | `docker_container:` | `community.docker.docker_container:` |

--- a/skills/ansible-skill/references/execution-and-runtime.md
+++ b/skills/ansible-skill/references/execution-and-runtime.md
@@ -52,11 +52,10 @@ Minimal `execution-environment.yml` (builder v3 schema):
 version: 3
 images:
   base_image:
-    # In production, replace with `quay.io/ansible/creator-ee@sha256:<approved-digest>`.
-    name: quay.io/ansible/creator-ee:v24.12.0
+    name: quay.io/ansible/creator-ee@sha256:<approved-digest>
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.18.0
+    package_pip: ansible-core>=2.20,<2.21
   galaxy: requirements.yml
   python: requirements.txt
   system: bindep.txt

--- a/skills/ansible-skill/references/idempotency-patterns.md
+++ b/skills/ansible-skill/references/idempotency-patterns.md
@@ -13,7 +13,7 @@ Detail for the `Idempotency drift`, `Handler/ordering`, and `Check-mode blind sp
 | `ansible.builtin.blockinfile` | Yes | Markers delimit managed region | Changing `marker:` between runs produces two blocks |
 | `ansible.builtin.replace` | Yes | Regex substitution produced no change | Non-matching regex still reports `ok`, not failure — use `failed_when` |
 | `ansible.builtin.package` | Yes | Package manager reports already-installed | `state: latest` always re-resolves; heavier than `present` |
-| `ansible.builtin.service` / `systemd` | Yes | Running state + enabled state already match | `state: restarted` always reports `changed=True` |
+| `ansible.builtin.service` / `systemd_service` | Yes | Running state + enabled state already match | `state: restarted` always reports `changed=True` |
 | `ansible.builtin.cron` | Yes | Matches on `name:` in crontab comment | Changing only `minute:` without `name:` creates a duplicate |
 | `ansible.builtin.user` / `group` | Yes | Attribute diff against `/etc/passwd`/`/etc/group` | `password:` always re-hashes unless `update_password: on_create` |
 | `ansible.posix.mount` | Yes | fstab entry + mount state both match | `state: remounted` not idempotent; use `mounted`. Lives in the `ansible.posix` collection, not `ansible.builtin` |
@@ -51,7 +51,7 @@ Rules:
 - ❌ `ansible.builtin.shell: "curl -s https://api.example.com | jq .status"` → ✅ `ansible.builtin.uri: url=https://api.example.com return_content=yes` then `set_fact` from the JSON.
 - ❌ `ansible.builtin.command: rm -rf /tmp/build` (no guard) → ✅ `ansible.builtin.file: path=/tmp/build state=absent`.
 - ❌ `ansible.builtin.shell: "psql -c 'CREATE USER x'"` (runs every time, fails on 2nd run) → ✅ `community.postgresql.postgresql_user: name=x state=present`.
-- ❌ `ansible.builtin.command: systemctl restart nginx` → ✅ `ansible.builtin.systemd: name=nginx state=restarted` (and only when a handler fires).
+- ❌ `ansible.builtin.command: systemctl restart nginx` → ✅ `ansible.builtin.systemd_service: name=nginx state=restarted` (and only when a handler fires).
 - ❌ `ansible.builtin.shell` with pipes where `command` would work → ✅ Split into two tasks or use the correct module per step.
 - ❌ Omitting `changed_when` on an **unguarded** `command`/`shell` → ✅ Set it explicitly. Use `changed_when: false` for read-only status probes; for one-shot commands already guarded by `creates:`/`removes:`, the guard makes the task idempotent on its own and `changed_when` is not required (and `changed_when: false` would actively hide the legitimate first-run change).
 
@@ -93,7 +93,7 @@ Rules:
 |-----------------|------------------|------------|
 | File-manipulation (`copy`, `template`, `file`, `lineinfile`) | Yes | None |
 | Package (`package`, `dnf`, `apt`, `yum`) | Yes | None |
-| Service (`service`, `systemd`) | Yes | None — but `state: restarted` always reports would-change |
+| Service (`service`, `systemd_service`) | Yes | None — but `state: restarted` always reports would-change |
 | `command` / `shell` | **No by default** | For read-only probes: `check_mode: no` + `changed_when: false`. For mutating commands: gate with `when: not ansible_check_mode`. **Never** force `check_mode: yes` on a `command`/`shell` — it makes the task check-mode in *real* runs too, silently skipping execution and leaving `register` output undefined |
 | Custom modules | Depends on module | Support is implemented in the module code itself — pass `supports_check_mode=True` to `AnsibleModule(...)` in the module's Python source. (Role `meta/argument_specs.yml` is unrelated — that validates role inputs, not module check-mode behavior.) Otherwise the task is skipped silently under `--check` |
 | API / `uri` to external | Depends on endpoint | Wrap in `when: not ansible_check_mode` for mutating calls |
@@ -109,7 +109,7 @@ Rules:
 ### LLM Mistake Checklist
 
 - ❌ Emit `ansible.builtin.shell: "rm -rf {{ path }}"` with no guard → ✅ `ansible.builtin.file: path="{{ path }}" state=absent`.
-- ❌ Recommend `command: systemctl restart X` at the top of a play → ✅ `ansible.builtin.systemd` in a handler, notified by the config task.
+- ❌ Recommend `command: systemctl restart X` at the top of a play → ✅ `ansible.builtin.systemd_service` in a handler, notified by the config task.
 - ❌ Treat `uri` as always idempotent → ✅ `POST` is only idempotent if the server guarantees it; default to GET/PUT where possible.
 - ❌ Skip `changed_when` on an `ansible.builtin.command` "because it's informational" → ✅ Set `changed_when: false` explicitly.
 - ❌ Chain handlers via `notify:` from inside another handler → ✅ Modern ansible-core does allow handler-to-handler notify while the handler queue is running, but the resulting ordering and visibility are easy to get wrong; prefer flat `listen:` topics where many tasks fan into one logical action.

--- a/skills/ansible-skill/references/quick-reference.md
+++ b/skills/ansible-skill/references/quick-reference.md
@@ -74,7 +74,7 @@ When a play fails, walk this tree top-down.
 | Goal | Preferred module | Minimal example |
 |------|------------------|-----------------|
 | Install package (any distro) | `ansible.builtin.package` | `ansible.builtin.package: name=nginx state=present` |
-| Start/enable a systemd unit | `ansible.builtin.systemd` | `ansible.builtin.systemd: name=nginx state=started enabled=true` |
+| Start/enable a systemd unit | `ansible.builtin.systemd_service` | `ansible.builtin.systemd_service: name=nginx state=started enabled=true` |
 | Copy a file (with backup) | `ansible.builtin.copy` | `ansible.builtin.copy: src=nginx.conf dest=/etc/nginx/nginx.conf backup=yes` |
 | Render a template | `ansible.builtin.template` | `ansible.builtin.template: src=app.conf.j2 dest=/etc/app.conf mode=0640` |
 | Create/write a small file | `ansible.builtin.file` + `ansible.builtin.copy` | `ansible.builtin.file: path=/opt/app state=directory mode=0755` then `ansible.builtin.copy: content='...' dest=/opt/app/version` |
@@ -94,13 +94,15 @@ When a play fails, walk this tree top-down.
 
 ## Version Matrix
 
-| `ansible-core` | Community `ansible` pkg | Release | EOL | EE image tag (OpenShift / creator-ee) |
-|-----------------|--------------------------|---------|-----|---------------------------------------|
-| 2.14 | 7.x | 2022-11 | 2024-05 (EOL) | `creator-ee:v0.21.0` |
-| 2.15 | 8.x | 2023-05 | 2024-11 (EOL) | `creator-ee:v0.22.0` |
-| 2.16 | 9.x | 2023-11 | 2025-05 | `creator-ee:v24.3.0` |
-| 2.17 | 10.x | 2024-05 | 2025-11 | `creator-ee:v24.7.0` |
-| 2.18 | 11.x | 2024-11 | 2026-05 | `creator-ee:v24.12.0` |
+| `ansible-core` | Community `ansible` pkg | Release | EOL | Guidance |
+|-----------------|--------------------------|---------|-----|----------|
+| 2.14 | 7.x | 2022-11 | 2024-05 (EOL) | Do not recommend |
+| 2.15 | 8.x | 2023-05 | 2024-11 (EOL) | Do not recommend |
+| 2.16 | 9.x | 2023-11 | 2025-07 (EOL) | Do not recommend |
+| 2.17 | 10.x | 2024-05 | 2025-11 (EOL) | Do not recommend |
+| 2.18 | 11.x | 2024-11 | 2026-05 | Security-only; avoid for new work |
+| 2.19 | 12.x | 2025-07 | 2026-11 | Minimum floor with EOL runway |
+| 2.20 | 13.x | 2025-11 | 2027-05 | Preferred current production floor |
 
 Rules:
 


### PR DESCRIPTION
## Summary
- Add Codex and Claude plugin manifests plus a no-dependency package validator.
- Replace fragmented validation jobs with a package validation flow that runs on PRs and pushes to master.
- Update release automation to generate GitHub Releases after tagging and correctly classify scoped breaking commits / BREAKING CHANGE footers.
- Refresh Ansible support guidance for 2.19/2.20, avoid near-EOL 2.18 for new work, and use canonical ansible.builtin.systemd_service.
- Fix README/docs inconsistencies from review.

Closes #23

## Validation
- python3 scripts/validate_skill.py
- python3 -m py_compile scripts/validate_skill.py .github/scripts/bump-version.py
- git diff --check --cached

## Release
The missing GitHub Release for the current tag was published and verified:
https://github.com/olandodeflexy/ansible-skill/releases/tag/v0.1.1

After this PR is merged to master, the updated release workflow will create future GitHub Releases automatically from the generated tag and notes.